### PR TITLE
Feature: 사용자는 로그인할 수 있다. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.thirdparty.ticketing.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.ZonedDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private ZonedDateTime createdAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
@@ -4,25 +4,25 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.ZonedDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class BaseEntity {
 
-    @CreatedDate
     @Column(updatable = false)
     private ZonedDateTime createdAt;
 
     @LastModifiedDate
     private ZonedDateTime updatedAt;
 
-    @CreatedBy
-    @Column(updatable = false)
-    private String createdBy;
+    public BaseEntity(ZonedDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
@@ -4,16 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.ZonedDateTime;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class BaseEntity {
 
     @Column(updatable = false)
@@ -21,6 +18,10 @@ public abstract class BaseEntity {
 
     @LastModifiedDate
     private ZonedDateTime updatedAt;
+
+    public BaseEntity() {
+        createdAt = ZonedDateTime.now();
+    }
 
     public BaseEntity(ZonedDateTime createdAt) {
         this.createdAt = createdAt;

--- a/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/BaseEntity.java
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -17,6 +18,9 @@ public abstract class BaseEntity {
     @CreatedDate
     @Column(updatable = false)
     private ZonedDateTime createdAt;
+
+    @LastModifiedDate
+    private ZonedDateTime updatedAt;
 
     @CreatedBy
     @Column(updatable = false)

--- a/src/main/java/com/thirdparty/ticketing/domain/common/TicketingException.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/common/TicketingException.java
@@ -1,0 +1,12 @@
+package com.thirdparty.ticketing.domain.common;
+
+public class TicketingException extends RuntimeException {
+
+    public TicketingException(String message) {
+        super(message);
+    }
+
+    public TicketingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +30,8 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private MemberRole memberRole;
 
-    public Member(String email, String password, MemberRole memberRole) {
+    public Member(String email, String password, MemberRole memberRole, ZonedDateTime createdAt) {
+        super(createdAt);
         this.email = email;
         this.password = password;
         this.memberRole = memberRole;

--- a/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
@@ -30,6 +30,12 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private MemberRole memberRole;
 
+    public Member(String email, String password, MemberRole memberRole) {
+        this.email = email;
+        this.password = password;
+        this.memberRole = memberRole;
+    }
+
     public Member(String email, String password, MemberRole memberRole, ZonedDateTime createdAt) {
         super(createdAt);
         this.email = email;

--- a/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
@@ -1,0 +1,37 @@
+package com.thirdparty.ticketing.domain.member;
+
+import com.thirdparty.ticketing.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+
+    private String email;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole memberRole;
+
+    public Member(String email, String password, MemberRole memberRole) {
+        this.email = email;
+        this.password = password;
+        this.memberRole = memberRole;
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/MemberRole.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/MemberRole.java
@@ -1,0 +1,22 @@
+package com.thirdparty.ticketing.domain.member;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum MemberRole {
+    USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
+
+    private final String value;
+
+    MemberRole(String value) {
+        this.value = value;
+    }
+
+    public static MemberRole find(String value) {
+        return Arrays.stream(values())
+                .filter(role -> role.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 역할이 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/controller/AuthController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.thirdparty.ticketing.domain.member.controller;
+
+import com.thirdparty.ticketing.domain.member.controller.request.LoginRequest;
+import com.thirdparty.ticketing.domain.member.service.AuthService;
+import com.thirdparty.ticketing.domain.member.service.response.LoginResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(
+            @Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request.getEmail(), request.getPassword());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/controller/request/LoginRequest.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/controller/request/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.thirdparty.ticketing.domain.member.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+public class LoginRequest {
+    @Email(message = "이메일 형식이 유효하지 않습니다.")
+    @NotBlank(message = "이메일은 공백일 수 없습니다.")
+    private String email;
+
+    @Length(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    private String password;
+
+    public LoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.thirdparty.ticketing.domain.member.repository;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/AuthService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/AuthService.java
@@ -1,0 +1,27 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
+import com.thirdparty.ticketing.domain.member.service.response.LoginResponse;
+import jakarta.transaction.Transactional;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    public LoginResponse login(String email, String rawPassword) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NoSuchElementException("이메일/비밀번호가 일치하지 않습니다."));
+        passwordEncoder.checkMatches(member, rawPassword);
+        String accessToken =  jwtProvider.createAccessToken(member);
+        return LoginResponse.of(member, accessToken);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/ExpiredTokenException.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/ExpiredTokenException.java
@@ -1,0 +1,7 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+public class ExpiredTokenException extends RuntimeException{
+    public ExpiredTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/ExpiredTokenException.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/ExpiredTokenException.java
@@ -1,6 +1,8 @@
 package com.thirdparty.ticketing.domain.member.service;
 
-public class ExpiredTokenException extends RuntimeException{
+import com.thirdparty.ticketing.domain.common.TicketingException;
+
+public class ExpiredTokenException extends TicketingException {
     public ExpiredTokenException(String message) {
         super(message);
     }

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/InvalidTokenException.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/InvalidTokenException.java
@@ -1,6 +1,8 @@
 package com.thirdparty.ticketing.domain.member.service;
 
-public class InvalidTokenException extends RuntimeException {
+import com.thirdparty.ticketing.domain.common.TicketingException;
+
+public class InvalidTokenException extends TicketingException {
     public InvalidTokenException(String message) {
         super(message);
     }

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/InvalidTokenException.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/JwtProvider.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/JwtProvider.java
@@ -1,0 +1,10 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.service.response.CustomClaims;
+
+public interface JwtProvider {
+    CustomClaims parseAccessToken(String accessToken);
+
+    String createAccessToken(Member member);
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/PasswordEncoder.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/PasswordEncoder.java
@@ -1,0 +1,9 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+import com.thirdparty.ticketing.domain.member.Member;
+
+public interface PasswordEncoder {
+    String encode(String rawPassword);
+
+    void checkMatches(Member member, String rawPassword);
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/response/CustomClaims.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/response/CustomClaims.java
@@ -1,0 +1,15 @@
+package com.thirdparty.ticketing.domain.member.service.response;
+
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import lombok.Data;
+
+@Data
+public class CustomClaims {
+    private Long memberId;
+    private MemberRole memberRole;
+
+    public CustomClaims(Long memberId, MemberRole memberRole) {
+        this.memberId = memberId;
+        this.memberRole = memberRole;
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/response/LoginResponse.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/response/LoginResponse.java
@@ -1,0 +1,19 @@
+package com.thirdparty.ticketing.domain.member.service.response;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import lombok.Data;
+
+@Data
+public class LoginResponse {
+    private Long memberId;
+    private String accessToken;
+
+    public LoginResponse(Long memberId, String accessToken) {
+        this.memberId = memberId;
+        this.accessToken = accessToken;
+    }
+
+    public static LoginResponse of(Member member, String accessToken) {
+        return new LoginResponse(member.getMemberId(), accessToken);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/JpaConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/JpaConfig.java
@@ -1,0 +1,18 @@
+package com.thirdparty.ticketing.global.config;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+public class JpaConfig {
+
+    @Bean
+    public DateTimeProvider auditingDateTimeProvider() {
+        return () -> Optional.of(ZonedDateTime.now());
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/SecurityConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.thirdparty.ticketing.global.config;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.member.service.PasswordEncoder;
+import com.thirdparty.ticketing.global.security.JJwtProvider;
+import java.util.NoSuchElementException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new PasswordEncoder() {
+            @Override
+            public String encode(String rawPassword) {
+                return new StringBuilder(rawPassword).reverse().toString();
+            }
+
+            @Override
+            public void checkMatches(Member member, String rawPassword) {
+                if (encode(rawPassword).equals(member.getPassword())) {
+                    return;
+                }
+                throw new NoSuchElementException("아이디/패스워드가 일치하지 않습니다.");
+            }
+        };
+    }
+
+    @Bean
+    public JwtProvider jwtProvider(
+            @Value("${jwt.issuer}") String issuer,
+            @Value("${jwt.expiry-seconds}") int expirySeconds,
+            @Value("${jwt.secret}") String secret) {
+        return new JJwtProvider(issuer, expirySeconds, secret);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/security/JJwtProvider.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/JJwtProvider.java
@@ -1,0 +1,66 @@
+package com.thirdparty.ticketing.global.security;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.ExpiredTokenException;
+import com.thirdparty.ticketing.domain.member.service.InvalidTokenException;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.member.service.response.CustomClaims;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JJwtProvider implements JwtProvider {
+
+    private static final String ROLE = "role";
+
+    private final String issuer;
+    private final int expirySeconds;
+    private final SecretKey secretKey;
+    private final JwtParser accessTokenParser;
+
+    public JJwtProvider(String issuer, int expirySeconds, String secret) {
+        this.issuer = issuer;
+        this.expirySeconds = expirySeconds;
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenParser = Jwts.parser()
+                .verifyWith(secretKey)
+                .build();
+    }
+
+    @Override
+    public CustomClaims parseAccessToken(String accessToken) {
+        try {
+            Claims payload = accessTokenParser.parseSignedClaims(accessToken).getPayload();
+            Long memberId = Long.valueOf(payload.getSubject());
+            MemberRole memberRole = MemberRole.find(payload.get(ROLE, String.class));
+            return new CustomClaims(memberId, memberRole);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException("액세스 토큰이 만료되었습니다.");
+        } catch (RuntimeException e) {
+            log.debug("액세스 토큰이 유효하지 않습니다. token={}", accessToken);
+            throw new InvalidTokenException("액세스 토큰이 유효하지 않습니다.", e);
+        }
+    }
+
+    @Override
+    public String createAccessToken(Member member) {
+        Date now = new Date();
+        Date expiresAt = new Date(now.getTime() + expirySeconds * 1000L);
+        return Jwts.builder()
+                .issuer(issuer)
+                .issuedAt(now)
+                .subject(member.getMemberId().toString())
+                .expiration(expiresAt)
+                .claim(ROLE, member.getMemberRole().getValue())
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ticketing

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+jwt:
+  issuer: test
+  expiry-seconds: 1800
+  secret: thisisjusttestaccesssecretsodontworry

--- a/src/test/java/com/thirdparty/ticketing/domain/member/service/AuthServiceTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/service/AuthServiceTest.java
@@ -1,0 +1,114 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
+import com.thirdparty.ticketing.domain.member.service.response.LoginResponse;
+import com.thirdparty.ticketing.global.security.JJwtProvider;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class AuthServiceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private PasswordEncoder passwordEncoder;
+    private JwtProvider jwtProvider = new JJwtProvider(
+            "test", 3600,
+            "thisisjusttestaccesssecretsodontworry");
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new PasswordEncoder() {
+
+            @Override
+            public String encode(String rawPassword) {
+                return new StringBuilder(rawPassword).reverse().toString();
+            }
+
+            @Override
+            public void checkMatches(Member member, String rawPassword) {
+                String encodedPassword = encode(rawPassword);
+                if (encodedPassword.equals(member.getPassword())) {
+                    return;
+                }
+                throw new NoSuchElementException("이메일/패스워드가 일치하지 않습니다.");
+            }
+        };
+    }
+
+    @Nested
+    @DisplayName("로그인 메서드 호출 시")
+    class LoginTest {
+
+        private String email;
+        private String rawPassword;
+        private Member savedMember;
+        private AuthService authService;
+
+        @BeforeEach
+        void setUp() {
+            email = "test@test.com";
+            rawPassword = "test1234";
+            String password = passwordEncoder.encode(rawPassword);
+            MemberRole memberRole = MemberRole.USER;
+            savedMember = new Member(email, password, memberRole);
+            authService = new AuthService(
+                    memberRepository,
+                    passwordEncoder,
+                    jwtProvider);
+        }
+
+        @Test
+        @DisplayName("액세스 토큰과 회원 ID를 반환한다.")
+        void login() {
+            //given
+            memberRepository.save(savedMember);
+
+            //when
+            LoginResponse response = authService.login(email, rawPassword);
+
+            //then
+            assertThat(response.getAccessToken()).isNotBlank();
+            assertThat(response.getMemberId()).isEqualTo(savedMember.getMemberId());
+        }
+
+        @Test
+        @DisplayName("예외(noSuchElement): 이메일과 일치하는 회원이 없으면")
+        void noSuchElement_WhenEmailIsNotMatches() {
+            //given
+            String wrongEmail = "wrongEmail";
+            memberRepository.save(savedMember);
+
+            //when
+            Exception exception = catchException(() -> authService.login(wrongEmail, rawPassword));
+
+            //then
+            assertThat(exception).isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        @DisplayName("예외(noSuchElement): 회원의 비밀번호와 일치하지 않으면")
+        void noSuchElement_WhenPasswordIsNotMatches() {
+            //given
+            String wrongPassword = "wrongPassword";
+            memberRepository.save(savedMember);
+
+            //when
+            Exception exception = catchException(() -> authService.login(email, wrongPassword));
+
+            //then
+            assertThat(exception).isInstanceOf(NoSuchElementException.class);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/domain/member/service/AuthServiceTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/service/AuthServiceTest.java
@@ -8,6 +8,7 @@ import com.thirdparty.ticketing.domain.member.MemberRole;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
 import com.thirdparty.ticketing.domain.member.service.response.LoginResponse;
 import com.thirdparty.ticketing.global.security.JJwtProvider;
+import java.time.ZonedDateTime;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +63,7 @@ class AuthServiceTest {
             rawPassword = "test1234";
             String password = passwordEncoder.encode(rawPassword);
             MemberRole memberRole = MemberRole.USER;
-            savedMember = new Member(email, password, memberRole);
+            savedMember = new Member(email, password, memberRole, ZonedDateTime.now());
             authService = new AuthService(
                     memberRepository,
                     passwordEncoder,

--- a/src/test/java/com/thirdparty/ticketing/global/security/JJwtProviderTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/JJwtProviderTest.java
@@ -10,6 +10,7 @@ import com.thirdparty.ticketing.domain.member.service.ExpiredTokenException;
 import com.thirdparty.ticketing.domain.member.service.InvalidTokenException;
 import com.thirdparty.ticketing.domain.member.service.JwtProvider;
 import com.thirdparty.ticketing.domain.member.service.response.CustomClaims;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -43,7 +44,7 @@ class JJwtProviderTest {
         @DisplayName("새로운 액세스 토큰을 반환한다.")
         void createAccessToken() {
             //given
-            Member member = new Member("test@test.com", "password", MemberRole.USER);
+            Member member = new Member("test@test.com", "password", MemberRole.USER, ZonedDateTime.now());
             memberRepository.save(member);
 
             //when
@@ -63,7 +64,7 @@ class JJwtProviderTest {
 
         @BeforeEach
         void setUp() {
-            member = new Member("test@test.com", "password", MemberRole.USER);
+            member = new Member("test@test.com", "password", MemberRole.USER, ZonedDateTime.now());
             memberRepository.save(member);
 
             accessToken = jwtProvider.createAccessToken(member);

--- a/src/test/java/com/thirdparty/ticketing/global/security/JJwtProviderTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/JJwtProviderTest.java
@@ -1,0 +1,115 @@
+package com.thirdparty.ticketing.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
+import com.thirdparty.ticketing.domain.member.service.ExpiredTokenException;
+import com.thirdparty.ticketing.domain.member.service.InvalidTokenException;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.member.service.response.CustomClaims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class JJwtProviderTest {
+    private String issuer;
+    private int expirySeconds;
+    private String secret;
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        issuer = "test";
+        expirySeconds = 3600;
+        secret = "thisisjusttestaccesssecretsodontworry";
+        jwtProvider = new JJwtProvider(issuer, expirySeconds, secret);
+    }
+
+    @Nested
+    @DisplayName("액세스 토큰 생성 메서드 실행 시")
+    class CreateAccessTokenTest {
+
+        @Test
+        @DisplayName("새로운 액세스 토큰을 반환한다.")
+        void createAccessToken() {
+            //given
+            Member member = new Member("test@test.com", "password", MemberRole.USER);
+            memberRepository.save(member);
+
+            //when
+            String accessToken = jwtProvider.createAccessToken(member);
+
+            //then
+            assertThat(accessToken).isNotBlank();
+        }
+    }
+
+    @Nested
+    @DisplayName("액세스 토큰 분석 메서드 실행 시")
+    class ParseAccessTokenTest {
+
+        private Member member;
+        private String accessToken;
+
+        @BeforeEach
+        void setUp() {
+            member = new Member("test@test.com", "password", MemberRole.USER);
+            memberRepository.save(member);
+
+            accessToken = jwtProvider.createAccessToken(member);
+        }
+
+        @Test
+        @DisplayName("분석한 토큰 페이로드를 반환한다.")
+        void parseAccessToken() {
+            //given
+
+            //when
+            CustomClaims customClaims = jwtProvider.parseAccessToken(accessToken);
+
+            //then
+            assertThat(customClaims.getMemberId()).isEqualTo(member.getMemberId());
+            assertThat(customClaims.getMemberRole()).isEqualTo(member.getMemberRole());
+        }
+
+        @Test
+        @DisplayName("예외(invalidToken): 액세스 토큰이 유효하지 않으면")
+        void invalidToken_WhenAccessTokenIsInvalid() {
+            //given
+            String notEqualSecret = secret + "asdf";
+            JJwtProvider invalidJJwtProvider = new JJwtProvider(issuer, expirySeconds, notEqualSecret);
+            String invalidAccessToken = invalidJJwtProvider.createAccessToken(member);
+
+            //when
+            Exception exception = catchException(() -> jwtProvider.parseAccessToken(invalidAccessToken));
+
+            //then
+            assertThat(exception).isInstanceOf(InvalidTokenException.class);
+        }
+
+        @Test
+        @DisplayName("예외(expiredToken): 액세스 토큰이 만료되었으면")
+        void expiredToken_WhenAccessTokenIsExpired() {
+            //given
+            int alreadyExpiredSeconds = -1;
+            JJwtProvider expiredJJwtProvider = new JJwtProvider(issuer, alreadyExpiredSeconds, secret);
+            String expiredAccessToken = expiredJJwtProvider.createAccessToken(member);
+
+            //when
+            Exception exception = catchException(() -> jwtProvider.parseAccessToken(expiredAccessToken));
+
+            //then
+            assertThat(exception).isInstanceOf(ExpiredTokenException.class);
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 회원 엔티티를 구현하였습니다.
  - 회원의 유저, 어드민 역할을 구분하기  위한 `MemberRole` 이넘을 추가했습니다.
- 로그인 기능을 구현하였습니다.
  - 입력받은 이메일로 회원을 조회합니다.
  - 입력받은 패스워드와 패스워드 인코더를 이용하여 회원의 암호화된 패스워드와 일치하는지 확인합니다.
  - 모두 일치하면 jwt 토큰 생성기를 이용하여 액세스 토큰을 생성하고 반환합니다.
- jwt 토큰 생성기를 구현하였습니다.
  - jwt 구현체로 사용하기 위한 jjwt 라이브러리 의존성을 추가하였습니다.


### 📝 작업 요약
- 회원 엔티티 구현
- 로그인 기능 구현
- jwt 토큰 생성기 구현

### 💡 관련 이슈
- close #2 
