### PR TITLE
Setting: API 문서화 도구는 SpringRestDocs를 사용한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.thirdparty'
@@ -14,6 +15,7 @@ java {
 }
 
 configurations {
+    asciidoctorExt
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -21,6 +23,10 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+ext {
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
@@ -33,8 +39,32 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('test') {
+    outputs.dir snippetsDir
     useJUnitPlatform()
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -12,3 +12,25 @@
 = 장소(Place)
 
 = 티켓(Ticket)
+
+= API 문서화 예시
+
+== GET 문서화
+
+=== request
+
+operation::documentation-test/get-docs[snippets='http-request,query-parameters']
+
+=== response
+
+operation::documentation-test/get-docs[snippets='http-response,response-fields']
+
+== POST 문서화
+
+=== request
+
+operation::documentation-test/post-docs[snippets='http-request,path-parameters,request-fields']
+
+=== response
+
+operation::documentation-test/post-docs[snippets='http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,14 @@
+= API 문서
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+= 회원(Member)
+
+= 공연(Performance)
+
+= 장소(Place)
+
+= 티켓(Ticket)

--- a/src/test/java/com/thirdparty/ticketing/support/DocumentationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/DocumentationTest.java
@@ -1,0 +1,112 @@
+package com.thirdparty.ticketing.support;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.support.DocumentationTest.DocsController;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Import(DocsController.class)
+@DisplayName("API 문서 테스트 코드 작성 시")
+public class DocumentationTest extends RestDocsControllerTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    public record HelloRequest(String name) {
+
+    }
+
+    @RestController
+    @RequestMapping("/test/docs")
+    public static class DocsController {
+
+        @GetMapping("/hello")
+        public ResponseEntity<Map<String, String>> hello(@RequestParam("name") String name) {
+            Map<String, String> map = new HashMap<>();
+            map.put("hello", name);
+            return ResponseEntity.ok(map);
+        }
+
+        @PostMapping("/hello/{test}")
+        public ResponseEntity<Map<String, String>> hello2(@PathVariable("test") Long testVariable,
+                                                          @RequestBody HelloRequest request) {
+            Map<String, String> map = new HashMap<>();
+            map.put("hello", request.name);
+            map.put("pathVariable", testVariable.toString());
+            return ResponseEntity.ok(map);
+        }
+    }
+
+    @Test
+    @DisplayName("GET 요청을 다음과 같이 문서화 할 수 있다.")
+    public void getDocs() throws Exception {
+        //given
+
+        //when
+        ResultActions result = mockMvc.perform(get("/test/docs/hello")
+                .param("name", "ticket"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        queryParameters(
+                                parameterWithName("name").description("이름")
+                        ),
+                        responseFields(
+                                fieldWithPath("hello").type(JsonFieldType.STRING).description("안녕, 이름")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("POST 요청은 다음과 같이 문서화 할 수 있다.")
+    void postDocs() throws Exception {
+        //given
+        String content = objectMapper.writeValueAsString(new HelloRequest("name"));
+
+        //when
+        ResultActions result = mockMvc.perform(post("/test/docs/hello/{test}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content));
+
+        //then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("test").description("테스트용 경로 변수")
+                        ),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
+                        ),
+                        responseFields(
+                                fieldWithPath("pathVariable").type(JsonFieldType.STRING).description("경로 변수"),
+                                fieldWithPath("hello").type(JsonFieldType.STRING).description("안녕, 이름")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
@@ -1,0 +1,60 @@
+package com.thirdparty.ticketing.support;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.thirdparty.ticketing.support.RestDocsControllerTest.RestDocsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@WebMvcTest
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsControllerTest {
+
+    @TestConfiguration
+    public static class RestDocsConfig {
+
+        @Bean
+        public RestDocumentationResultHandler write() {
+            return MockMvcRestDocumentation.document(
+                    "{class-name}/{method-name}",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint())
+            );
+        }
+    }
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @BeforeEach
+    void setUp(
+            WebApplicationContext applicationContext,
+            RestDocumentationContextProvider documentationContextProvider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(applicationContext)
+                .alwaysDo(print())
+                .alwaysDo(restDocs)
+                .apply(
+                        MockMvcRestDocumentation.documentationConfiguration(documentationContextProvider))
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- SpringRestDocs 의존성과 설정 정보를 추가했습니다.
- restDocs 사용 시 발생하는 중복 코드를 제거했습니다. 컨트롤러 테스트 코드 작성 시 `RestDocsControllerTest`를 상속해서 작성해주세요.
- restDocs의 작동 여부를 검증하면서 문서화 예시 코드를 추가했습니다.
  - 문서화 시 생성되는 코드 스니펫의 이름은 `클래스 이름/메서드 이름`으로 생성됩니다.
  - src/docs/asciidoc/index.adoc는 api 문서화 파일입니다. 작성 예시를 추가해뒀습니다.


### 📝 작업 요약
- SpringRestDocs 문서화 세팅

### 💡 관련 이슈
- close #6 
