### PR TITLE
Feature: 사용자의 요청은 인증 프로세스를 통과해야 한다.

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/response/CustomClaims.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/response/CustomClaims.java
@@ -2,14 +2,11 @@ package com.thirdparty.ticketing.domain.member.service.response;
 
 import com.thirdparty.ticketing.domain.member.MemberRole;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 @Data
+@RequiredArgsConstructor
 public class CustomClaims {
-    private Long memberId;
-    private MemberRole memberRole;
-
-    public CustomClaims(Long memberId, MemberRole memberRole) {
-        this.memberId = memberId;
-        this.memberRole = memberRole;
-    }
+    private final String email;
+    private final MemberRole memberRole;
 }

--- a/src/main/java/com/thirdparty/ticketing/global/config/SecurityConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.thirdparty.ticketing.global.config;
 
 import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.global.security.AuthenticationContext;
 import com.thirdparty.ticketing.domain.member.service.JwtProvider;
 import com.thirdparty.ticketing.domain.member.service.PasswordEncoder;
 import com.thirdparty.ticketing.global.security.JJwtProvider;
@@ -11,6 +12,11 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public AuthenticationContext authenticationContext() {
+        return new AuthenticationContext();
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/thirdparty/ticketing/global/config/WebConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/WebConfig.java
@@ -1,0 +1,32 @@
+package com.thirdparty.ticketing.global.config;
+
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.global.security.AuthenticationContext;
+import com.thirdparty.ticketing.global.security.AuthenticationInterceptor;
+import com.thirdparty.ticketing.global.security.LoginMemberArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtProvider jwtProvider;
+    private final AuthenticationContext authenticationContext;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthenticationInterceptor(jwtProvider, authenticationContext))
+                .order(1)
+                .addPathPatterns("/api/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver(authenticationContext));
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/security/Authentication.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/Authentication.java
@@ -1,0 +1,24 @@
+package com.thirdparty.ticketing.global.security;
+
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Authentication {
+
+    private final String email;
+    private final MemberRole memberRole;
+    private final String accessToken;
+
+    public String getPrincipal() {
+        return email;
+    }
+
+    public String getAuthority() {
+        return memberRole.getValue();
+    }
+
+    public String getCredential() {
+        return accessToken;
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationContext.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationContext.java
@@ -1,0 +1,23 @@
+package com.thirdparty.ticketing.global.security;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AuthenticationContext {
+
+    private final ThreadLocal<Authentication> context = new ThreadLocal<>();
+
+    public void setAuthentication(Authentication authentication) {
+        context.set(authentication);
+        log.debug("[auth] 인증 컨텍스트 설정됨");
+    }
+
+    public Authentication getAuthentication() {
+        return context.get();
+    }
+
+    public void releaseContext() {
+        context.remove();
+        log.debug("[auth] 인증 컨텍스트 소멸됨");
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationException.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationException.java
@@ -1,0 +1,9 @@
+package com.thirdparty.ticketing.global.security;
+
+import com.thirdparty.ticketing.domain.common.TicketingException;
+
+public class AuthenticationException extends TicketingException {
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationInterceptor.java
@@ -50,6 +50,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
             throws Exception {
-        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+        authenticationContext.releaseContext();
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/AuthenticationInterceptor.java
@@ -1,0 +1,55 @@
+package com.thirdparty.ticketing.global.security;
+
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.member.service.response.CustomClaims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private static final String HEADER = "Authorization";
+    private static final String BEARER = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final AuthenticationContext authenticationContext;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        log.debug("[auth] JWT 인증 인터셉터 시작");
+        String bearerAccessToken = request.getHeader(HEADER);
+        if(Objects.nonNull(bearerAccessToken)) {
+            log.debug("[auth] JWT 인증 프로세스 시작");
+            String accessToken = removeBearer(bearerAccessToken);
+            Authentication authentication = authenticate(accessToken);
+            authenticationContext.setAuthentication(authentication);
+            log.debug("[auth] JWT 인증 프로세스 종료. 사용자 인증됨. principal={}", authentication.getPrincipal());
+        }
+        log.debug("[auth] Jwt 인증 인터셉터 종료");
+        return true;
+    }
+
+    private String removeBearer(String bearerAccessToken) {
+        if(bearerAccessToken.contains(BEARER)) {
+            return bearerAccessToken.replace(BEARER, "");
+        }
+        throw new AuthenticationException("액세스 토큰 형식이 옮바르지 않습니다.");
+    }
+
+    private Authentication authenticate(String accessToken) {
+        CustomClaims customClaims = jwtProvider.parseAccessToken(accessToken);
+        return new Authentication(customClaims.getEmail(), customClaims.getMemberRole(), accessToken);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/security/JJwtProvider.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/JJwtProvider.java
@@ -39,9 +39,9 @@ public class JJwtProvider implements JwtProvider {
     public CustomClaims parseAccessToken(String accessToken) {
         try {
             Claims payload = accessTokenParser.parseSignedClaims(accessToken).getPayload();
-            Long memberId = Long.valueOf(payload.getSubject());
+            String email = payload.getSubject();
             MemberRole memberRole = MemberRole.find(payload.get(ROLE, String.class));
-            return new CustomClaims(memberId, memberRole);
+            return new CustomClaims(email, memberRole);
         } catch (ExpiredJwtException e) {
             throw new ExpiredTokenException("액세스 토큰이 만료되었습니다.");
         } catch (RuntimeException e) {
@@ -57,7 +57,7 @@ public class JJwtProvider implements JwtProvider {
         return Jwts.builder()
                 .issuer(issuer)
                 .issuedAt(now)
-                .subject(member.getMemberId().toString())
+                .subject(member.getEmail())
                 .expiration(expiresAt)
                 .claim(ROLE, member.getMemberRole().getValue())
                 .signWith(secretKey)

--- a/src/main/java/com/thirdparty/ticketing/global/security/LoginMember.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/LoginMember.java
@@ -1,0 +1,11 @@
+package com.thirdparty.ticketing.global.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.thirdparty.ticketing.global.security;
+
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthenticationContext authenticationContext;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasParameterAnnotation = parameter.hasParameterAnnotation(LoginMember.class);
+        boolean hasLongParameterType = parameter.getParameterType().isAssignableFrom(String.class);
+        return hasParameterAnnotation && hasLongParameterType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = authenticationContext.getAuthentication();
+        checkAuthenticated(authentication);
+        return authentication.getPrincipal();
+    }
+
+    private void checkAuthenticated(Authentication authentication) {
+        if (authentication != null) {
+            return;
+        }
+        throw new AuthenticationException("인증되지 않은 사용자 요청입니다.");
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/security/AuthenticationInterceptorTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/AuthenticationInterceptorTest.java
@@ -1,0 +1,149 @@
+package com.thirdparty.ticketing.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class AuthenticationInterceptorTest {
+
+    private AuthenticationInterceptor authenticationInterceptor;
+    private JwtProvider jwtProvider;
+    private AuthenticationContext authenticationContext;
+
+    @BeforeEach
+    void setUp() {
+        authenticationContext = new AuthenticationContext();
+        jwtProvider = new JJwtProvider("test", 3600, "thisisjusttestaccesssecretsodontworry");
+        authenticationInterceptor = new AuthenticationInterceptor(jwtProvider,
+            authenticationContext);
+    }
+
+    @Nested
+    @DisplayName("preHandle 호출 시")
+    class PreHandleTest {
+
+        MockHttpServletRequest httpServletRequest;
+        MockHttpServletResponse httpServletResponse;
+
+        @BeforeEach
+        void setUp() {
+            httpServletRequest = new MockHttpServletRequest();
+            httpServletResponse = new MockHttpServletResponse();
+        }
+
+        @Nested
+        @DisplayName("authorization 헤더가 포함되어 있으면")
+        class ContainsAuthorizationHeader {
+
+            private Member member;
+            private String accessToken;
+
+            @BeforeEach
+            void setUp() {
+                member = new Member("email@email.com", "password", MemberRole.USER);
+                accessToken = jwtProvider.createAccessToken(member);
+            }
+
+            @Test
+            @DisplayName("인증 프로세스를 진행한다.")
+            void runAuthenticationProcess_WhenContainsAuthorizationHeader() throws Exception {
+                //given
+                String bearerAccessToken = "Bearer " + accessToken;
+                httpServletRequest.addHeader("Authorization", bearerAccessToken);
+
+                //when
+                boolean result = authenticationInterceptor.preHandle(httpServletRequest,
+                    httpServletResponse,
+                    null);
+
+                //then
+                assertThat(result).isTrue();
+                Authentication authentication = authenticationContext.getAuthentication();
+                assertThat(authentication).isNotNull();
+            }
+
+            @Test
+            @DisplayName("예외(authentication): 액세스 토큰 형식이 Beaerer가 아니면")
+            void authentication_WhenAccessTokenTypeIsNotBearer() {
+                //given
+                String invalidAccessToken = "invalid" + accessToken;
+                httpServletRequest.addHeader("Authorization", invalidAccessToken);
+
+                //when
+                Exception exception = catchException(
+                    () -> authenticationInterceptor.preHandle(httpServletRequest,
+                        httpServletResponse, null));
+
+                //then
+                assertThat(exception).isInstanceOf(AuthenticationException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("Authorization 헤더가 포함되어 있지 않으면")
+        class NotContainsAuthorizationHeader {
+
+            @Test
+            @DisplayName("무시한다.")
+            void ignoreAuthenticationProcess_WhenNotContainsAuthorizationHeader() throws Exception {
+                //given
+                MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+                //when
+                boolean result = authenticationInterceptor.preHandle(mockHttpServletRequest,
+                    httpServletResponse,
+                    null);
+
+                //then
+                assertThat(result).isTrue();
+                Authentication authentication = authenticationContext.getAuthentication();
+                assertThat(authentication).isNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("afterCompletion 호출 시")
+    class AfterCompletionTest {
+
+        private MockHttpServletRequest httpServletRequest;
+        private MockHttpServletResponse httpServletResponse;
+        private Member member;
+        private String accessToken;
+
+        @BeforeEach
+        void setUp() {
+            httpServletRequest = new MockHttpServletRequest();
+            httpServletResponse = new MockHttpServletResponse();
+            member = new Member("email@email.com", "password", MemberRole.USER);
+            accessToken = jwtProvider.createAccessToken(member);
+        }
+
+        @Test
+        @DisplayName("인증 컨텍스트에서 사용자 정보를 제거한다.")
+        void afterCompletion() throws Exception {
+            //given
+            String bearerAccessToken = "Bearer " + accessToken;
+            httpServletRequest.addHeader("Authorization", bearerAccessToken);
+            authenticationInterceptor.preHandle(httpServletRequest, httpServletResponse,
+                null);
+
+            //when
+            authenticationInterceptor.afterCompletion(httpServletRequest,
+                httpServletResponse, null, null);
+
+            //then
+            Authentication authentication = authenticationContext.getAuthentication();
+            assertThat(authentication).isNull();
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/security/JJwtProviderTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/JJwtProviderTest.java
@@ -79,7 +79,7 @@ class JJwtProviderTest {
             CustomClaims customClaims = jwtProvider.parseAccessToken(accessToken);
 
             //then
-            assertThat(customClaims.getMemberId()).isEqualTo(member.getMemberId());
+            assertThat(customClaims.getEmail()).isEqualTo(member.getEmail());
             assertThat(customClaims.getMemberRole()).isEqualTo(member.getMemberRole());
         }
 

--- a/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
@@ -1,0 +1,61 @@
+package com.thirdparty.ticketing.global.security;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.global.security.LoginMemberArgumentResolverTest.ResolverTestController;
+import com.thirdparty.ticketing.support.RestDocsControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebMvcTest(controllers = ResolverTestController.class)
+class LoginMemberArgumentResolverTest extends RestDocsControllerTest {
+
+    @RestController
+    @RequestMapping("/api/test/resolver")
+    public static class ResolverTestController {
+
+        @GetMapping
+        public String resolve(@LoginMember String email) {
+            return email;
+        }
+    }
+
+    @Nested
+    @DisplayName("핸들러 메서드 파라미터에 @LoginMember가 포함되어 있으면")
+    class ParameterHasLoginMember {
+
+        private Member admin;
+        private String adminBearerToken;
+
+        @BeforeEach
+        void setUp() {
+            admin = new Member("admin@admin.com", "password", MemberRole.ADMIN);
+            adminBearerToken = "Bearer " + jwtProvider.createAccessToken(admin);
+        }
+
+        @Test
+        @DisplayName("인증 컨텍스트에서 사용자 이메일을 꺼내온다.")
+        void getLoginMemberEmail() throws Exception {
+            //given
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/test/resolver")
+                .header(AUTHORIZATION_HEADER, adminBearerToken));
+
+            //then
+            result.andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").value(admin.getEmail()));
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
 import com.thirdparty.ticketing.global.security.LoginMemberArgumentResolverTest.ResolverTestController;
-import com.thirdparty.ticketing.support.RestDocsControllerTest;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @WebMvcTest(controllers = ResolverTestController.class)
-class LoginMemberArgumentResolverTest extends RestDocsControllerTest {
+class LoginMemberArgumentResolverTest extends BaseControllerTest {
 
     @RestController
     @RequestMapping("/api/test/resolver")

--- a/src/test/java/com/thirdparty/ticketing/support/BaseControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/BaseControllerTest.java
@@ -10,7 +10,7 @@ import com.thirdparty.ticketing.domain.member.MemberRole;
 import com.thirdparty.ticketing.domain.member.service.JwtProvider;
 import com.thirdparty.ticketing.global.config.SecurityConfig;
 import com.thirdparty.ticketing.global.config.WebConfig;
-import com.thirdparty.ticketing.support.RestDocsControllerTest.RestDocsConfig;
+import com.thirdparty.ticketing.support.BaseControllerTest.RestDocsConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 @Import({RestDocsConfig.class, SecurityConfig.class, WebConfig.class})
 @ExtendWith(RestDocumentationExtension.class)
-public abstract class RestDocsControllerTest {
+public abstract class BaseControllerTest {
 
     protected static final String AUTHORIZATION_HEADER = "Authorization";
 
@@ -37,35 +37,35 @@ public abstract class RestDocsControllerTest {
 
     protected String adminBearerToken;
 
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
     @TestConfiguration
     public static class RestDocsConfig {
 
         @Bean
         public RestDocumentationResultHandler write() {
             return MockMvcRestDocumentation.document(
-                    "{class-name}/{method-name}",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint())
+                "{class-name}/{method-name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint())
             );
         }
     }
 
-    protected MockMvc mockMvc;
-
-    @Autowired
-    protected RestDocumentationResultHandler restDocs;
-
     @BeforeEach
     void setUp(
-            WebApplicationContext applicationContext,
-            RestDocumentationContextProvider documentationContextProvider) {
+        WebApplicationContext applicationContext,
+        RestDocumentationContextProvider documentationContextProvider) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(applicationContext)
-                .alwaysDo(print())
-                .alwaysDo(restDocs)
-                .apply(
-                        MockMvcRestDocumentation.documentationConfiguration(documentationContextProvider))
-                .addFilter(new CharacterEncodingFilter("UTF-8", true))
-                .build();
+            .alwaysDo(print())
+            .alwaysDo(restDocs)
+            .apply(
+                MockMvcRestDocumentation.documentationConfiguration(documentationContextProvider))
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .build();
 
         Member admin = new Member("admin@admin.com", "password", MemberRole.ADMIN);
         this.adminBearerToken = "Bearer " + jwtProvider.createAccessToken(admin);

--- a/src/test/java/com/thirdparty/ticketing/support/DocumentationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/DocumentationTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@WebMvcTest(controllers = DocumentationTest.class)
 @Import(DocsController.class)
 @DisplayName("API 문서 테스트 코드 작성 시")
 public class DocumentationTest extends RestDocsControllerTest {

--- a/src/test/java/com/thirdparty/ticketing/support/DocumentationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/DocumentationTest.java
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @WebMvcTest(controllers = DocumentationTest.class)
 @Import(DocsController.class)
 @DisplayName("API 문서 테스트 코드 작성 시")
-public class DocumentationTest extends RestDocsControllerTest {
+public class DocumentationTest extends BaseControllerTest {
 
     @Autowired
     ObjectMapper objectMapper;

--- a/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
@@ -5,7 +5,11 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
 import com.thirdparty.ticketing.global.config.SecurityConfig;
+import com.thirdparty.ticketing.global.config.WebConfig;
 import com.thirdparty.ticketing.support.RestDocsControllerTest.RestDocsConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,9 +26,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@Import({RestDocsConfig.class, SecurityConfig.class})
+@Import({RestDocsConfig.class, SecurityConfig.class, WebConfig.class})
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class RestDocsControllerTest {
+
+    protected static final String AUTHORIZATION_HEADER = "Authorization";
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    protected String adminBearerToken;
 
     @TestConfiguration
     public static class RestDocsConfig {
@@ -55,5 +66,8 @@ public abstract class RestDocsControllerTest {
                         MockMvcRestDocumentation.documentationConfiguration(documentationContextProvider))
                 .addFilter(new CharacterEncodingFilter("UTF-8", true))
                 .build();
+
+        Member admin = new Member("admin@admin.com", "password", MemberRole.ADMIN);
+        this.adminBearerToken = "Bearer " + jwtProvider.createAccessToken(admin);
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
@@ -9,7 +9,6 @@ import com.thirdparty.ticketing.support.RestDocsControllerTest.RestDocsConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -22,7 +21,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@WebMvcTest
 @Import(RestDocsConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class RestDocsControllerTest {

--- a/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/RestDocsControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import com.thirdparty.ticketing.global.config.SecurityConfig;
 import com.thirdparty.ticketing.support.RestDocsControllerTest.RestDocsConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +22,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@Import(RestDocsConfig.class)
+@Import({RestDocsConfig.class, SecurityConfig.class})
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class RestDocsControllerTest {
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 인증 컨텍스트를 구현했습니다. 
  - 스레드 로컬을 이용하여 사용자 인증 객체인 `Authentication`을 보관하는 컨텍스트입니다.
  - `Authentication`에는 사용자 이메일, 사용자 역할, 사용자의 액세스 토큰이 보관됩니다.
- 인증 인터셉터를 구현했습니다.
  - `Authorization` 헤더가 포함된 경우 사용자의 토큰이 올바른지 검증합니다.
  - 토큰의 claim으로부터 인증 객체를 생성합니다.
  - 생성한 인증 객체는 인증 컨텍스트에 보관합니다.
  - `Authorization` 헤더가 포함되지 않은 경우 무시합니다.
- 인증 정보 획득을 위한 아규먼트 리졸버를 구현했습니다.
  - 핸들러 메서드의 파라미터가 `@LoginMember` 어노테이션을 가지고 String 타입이면 인증 컨텍스트에서 사용자 이메일을 인자로 리졸브합니다.


### 📝 작업 요약
- 인증 프로세스 구현


### 💡 관련 이슈
- close #5 