### PR TITLE
Feature: 사용자는 회원가입 할 수 있다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,6 +7,16 @@
 
 = 회원(Member)
 
+== 회원 생성
+
+=== request
+
+operation::member-controller-test/create-member[snippets='http-request,request-fields']
+
+=== response
+
+operation::member-controller-test/create-member[snippets='http-response,response-fields']
+
 = 공연(Performance)
 
 = 장소(Place)

--- a/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
@@ -10,11 +10,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.ZonedDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Builder
+@AllArgsConstructor
 @Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {

--- a/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/Member.java
@@ -1,6 +1,7 @@
 package com.thirdparty.ticketing.domain.member;
 
 import com.thirdparty.ticketing.domain.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -27,10 +28,13 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
+    @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MemberRole memberRole;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/member/controller/MemberController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.thirdparty.ticketing.domain.member.controller;
 
-import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
+import com.thirdparty.ticketing.domain.member.controller.request.MemberCreationRequest;
 import com.thirdparty.ticketing.domain.member.service.MemberService;
 import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
 import jakarta.validation.Valid;
@@ -21,7 +21,7 @@ public class MemberController {
 
     @PostMapping
     public ResponseEntity<CreateMemberResponse> createMember(
-            @RequestBody @Valid CreateMemberRequest request) {
+            @RequestBody @Valid MemberCreationRequest request) {
         CreateMemberResponse response = memberService.createMember(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/src/main/java/com/thirdparty/ticketing/domain/member/controller/MemberController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.thirdparty.ticketing.domain.member.controller;
+
+import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
+import com.thirdparty.ticketing.domain.member.service.MemberService;
+import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<CreateMemberResponse> createMember(
+            @RequestBody @Valid CreateMemberRequest request) {
+        CreateMemberResponse response = memberService.createMember(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/controller/request/CreateMemberRequest.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/controller/request/CreateMemberRequest.java
@@ -1,0 +1,21 @@
+package com.thirdparty.ticketing.domain.member.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateMemberRequest {
+    @NotBlank(message = "이메일은 공백일 수 없습니다.")
+    @Email(message = "입력값이 이메일 형식을 만족하지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    @Length(min = 8, max = 20, message = "비밀번호는 8자 이상, 20자 이하여야 합니다.")
+    private String password;
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/controller/request/MemberCreationRequest.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/controller/request/MemberCreationRequest.java
@@ -10,7 +10,7 @@ import org.hibernate.validator.constraints.Length;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateMemberRequest {
+public class MemberCreationRequest {
     @NotBlank(message = "이메일은 공백일 수 없습니다.")
     @Email(message = "입력값이 이메일 형식을 만족하지 않습니다.")
     private String email;

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/DuplicateResourceException.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/DuplicateResourceException.java
@@ -1,0 +1,10 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+import com.thirdparty.ticketing.domain.common.TicketingException;
+
+public class DuplicateResourceException extends TicketingException {
+
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/MemberService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.domain.member.service;
 
 import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
 import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
 import jakarta.transaction.Transactional;
@@ -16,14 +17,14 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public CreateMemberResponse createMember(String email, String password) {
-        memberRepository.findByEmail(email)
+    public CreateMemberResponse createMember(CreateMemberRequest request) {
+        memberRepository.findByEmail(request.getEmail())
                 .ifPresent(member -> {
                     throw new DuplicateResourceException("중복된 이메일입니다.");
                 });
         Member member = Member.builder()
-                .email(email)
-                .password(passwordEncoder.encode(password))
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
                 .memberRole(MemberRole.USER)
                 .build();
         memberRepository.save(member);

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/MemberService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/MemberService.java
@@ -1,0 +1,32 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
+import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public CreateMemberResponse createMember(String email, String password) {
+        memberRepository.findByEmail(email)
+                .ifPresent(member -> {
+                    throw new DuplicateResourceException("중복된 이메일입니다.");
+                });
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .memberRole(MemberRole.USER)
+                .build();
+        memberRepository.save(member);
+        return CreateMemberResponse.from(member);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/MemberService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.thirdparty.ticketing.domain.member.service;
 
 import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
+import com.thirdparty.ticketing.domain.member.controller.request.MemberCreationRequest;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
 import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
 import jakarta.transaction.Transactional;
@@ -17,7 +17,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public CreateMemberResponse createMember(CreateMemberRequest request) {
+    public CreateMemberResponse createMember(MemberCreationRequest request) {
         memberRepository.findByEmail(request.getEmail())
                 .ifPresent(member -> {
                     throw new DuplicateResourceException("중복된 이메일입니다.");

--- a/src/main/java/com/thirdparty/ticketing/domain/member/service/response/CreateMemberResponse.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/member/service/response/CreateMemberResponse.java
@@ -1,0 +1,13 @@
+package com.thirdparty.ticketing.domain.member.service.response;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import lombok.Data;
+
+@Data
+public class CreateMemberResponse {
+    private final Long memberId;
+
+    public static CreateMemberResponse from(Member member) {
+        return new CreateMemberResponse(member.getMemberId());
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/SecurityConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/SecurityConfig.java
@@ -1,13 +1,12 @@
 package com.thirdparty.ticketing.global.config;
 
-import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
 import com.thirdparty.ticketing.domain.member.service.JwtProvider;
 import com.thirdparty.ticketing.domain.member.service.PasswordEncoder;
 import com.thirdparty.ticketing.global.security.AuthenticationFilter;
+import com.thirdparty.ticketing.global.security.BCryptPasswordEncoder;
 import com.thirdparty.ticketing.global.security.JJwtProvider;
 import java.util.List;
-import java.util.NoSuchElementException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -66,20 +65,7 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new PasswordEncoder() {
-            @Override
-            public String encode(String rawPassword) {
-                return new StringBuilder(rawPassword).reverse().toString();
-            }
-
-            @Override
-            public void checkMatches(Member member, String rawPassword) {
-                if (encode(rawPassword).equals(member.getPassword())) {
-                    return;
-                }
-                throw new NoSuchElementException("아이디/패스워드가 일치하지 않습니다.");
-            }
-        };
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/com/thirdparty/ticketing/global/security/BCryptPasswordEncoder.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/BCryptPasswordEncoder.java
@@ -1,0 +1,24 @@
+package com.thirdparty.ticketing.global.security;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.service.PasswordEncoder;
+import java.util.NoSuchElementException;
+
+public class BCryptPasswordEncoder implements PasswordEncoder {
+
+    private final org.springframework.security.crypto.password.PasswordEncoder passwordEncoder
+            = new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder();
+
+    @Override
+    public String encode(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public void checkMatches(Member member, String rawPassword) {
+        if (passwordEncoder.matches(rawPassword, member.getPassword())) {
+            return;
+        }
+        throw new NoSuchElementException("아이디/패스워드가 일치하지 않습니다.");
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
+import com.thirdparty.ticketing.domain.member.controller.request.MemberCreationRequest;
 import com.thirdparty.ticketing.domain.member.service.MemberService;
 import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
 import com.thirdparty.ticketing.support.BaseControllerTest;
@@ -35,7 +35,7 @@ class MemberControllerTest extends BaseControllerTest {
     @DisplayName("회원 생성 API 호출")
     void createMember() throws Exception {
         //given
-        CreateMemberRequest request = new CreateMemberRequest("eamil@email.com", "password");
+        MemberCreationRequest request = new MemberCreationRequest("eamil@email.com", "password");
 
         given(memberService.createMember(any())).willReturn(new CreateMemberResponse(1L));
 

--- a/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,59 @@
+package com.thirdparty.ticketing.domain.member.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
+import com.thirdparty.ticketing.domain.member.service.MemberService;
+import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
+import com.thirdparty.ticketing.support.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest extends BaseControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원 생성 API 호출")
+    void createMember() throws Exception {
+        //given
+        CreateMemberRequest request = new CreateMemberRequest("eamil@email.com", "password");
+
+        given(memberService.createMember(any())).willReturn(new CreateMemberResponse(1L));
+
+        //when
+        ResultActions result = mockMvc.perform(post("/api/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request)));
+
+        //then
+        result.andExpect(status().isCreated())
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원ID")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,86 @@
+package com.thirdparty.ticketing.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
+import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class MemberServiceTest {
+
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new PasswordEncoder() {
+            @Override
+            public String encode(String rawPassword) {
+                return new StringBuilder(rawPassword).reverse().toString();
+            }
+
+            @Override
+            public void checkMatches(Member member, String rawPassword) {
+                // 사용되지 않음
+            }
+        };
+        memberService = new MemberService(memberRepository, passwordEncoder);
+    }
+
+    @Nested
+    @DisplayName("회원 생성 메서드 호출 시")
+    class CreateMemberTest {
+
+        @Test
+        @DisplayName("회원을 생성한다.")
+        void createMember() {
+            //given
+            String email = "email@email.com";
+            String password = "password";
+
+            //when
+            CreateMemberResponse response = memberService.createMember(email, password);
+
+            //then
+            assertThat(memberRepository.findById(response.getMemberId()))
+                    .isNotEmpty()
+                    .get()
+                    .satisfies(member -> {
+                        assertThat(member.getEmail()).isEqualTo(email);
+                        assertThat(member.getPassword()).isEqualTo(passwordEncoder.encode(password));
+                        assertThat(member.getMemberRole()).isEqualTo(MemberRole.USER);
+                    });
+        }
+
+        @Test
+        @DisplayName("예외(duplicateResource): 중복된 이메일을 가진 회원이 있으면")
+        void duplicateResource_WhenDuplicateEmail() {
+            //given
+            String duplicateEmail = "duplicate@email.com";
+            Member member = Member.builder()
+                    .email(duplicateEmail)
+                    .password("password")
+                    .memberRole(MemberRole.USER)
+                    .build();
+            memberRepository.save(member);
+
+            //when
+            Exception exception = catchException(() -> memberService.createMember(duplicateEmail, "password"));
+
+            //then
+            assertThat(exception).isInstanceOf(DuplicateResourceException.class);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/service/MemberServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.catchException;
 
 import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
+import com.thirdparty.ticketing.domain.member.controller.request.MemberCreationRequest;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
 import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +50,7 @@ class MemberServiceTest {
             //given
             String email = "email@email.com";
             String password = "password";
-            CreateMemberRequest request = new CreateMemberRequest(email, password);
+            MemberCreationRequest request = new MemberCreationRequest(email, password);
 
             //when
             CreateMemberResponse response = memberService.createMember(request);
@@ -79,7 +79,7 @@ class MemberServiceTest {
                     .build();
             memberRepository.save(member);
 
-            CreateMemberRequest request = new CreateMemberRequest(duplicateEmail, password);
+            MemberCreationRequest request = new MemberCreationRequest(duplicateEmail, password);
 
             //when
             Exception exception = catchException(() -> memberService.createMember(request));

--- a/src/test/java/com/thirdparty/ticketing/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/service/MemberServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.catchException;
 
 import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.controller.request.CreateMemberRequest;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
 import com.thirdparty.ticketing.domain.member.service.response.CreateMemberResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,9 +50,10 @@ class MemberServiceTest {
             //given
             String email = "email@email.com";
             String password = "password";
+            CreateMemberRequest request = new CreateMemberRequest(email, password);
 
             //when
-            CreateMemberResponse response = memberService.createMember(email, password);
+            CreateMemberResponse response = memberService.createMember(request);
 
             //then
             assertThat(memberRepository.findById(response.getMemberId()))
@@ -69,15 +71,18 @@ class MemberServiceTest {
         void duplicateResource_WhenDuplicateEmail() {
             //given
             String duplicateEmail = "duplicate@email.com";
+            String password = "password";
             Member member = Member.builder()
                     .email(duplicateEmail)
-                    .password("password")
+                    .password(password)
                     .memberRole(MemberRole.USER)
                     .build();
             memberRepository.save(member);
 
+            CreateMemberRequest request = new CreateMemberRequest(duplicateEmail, password);
+
             //when
-            Exception exception = catchException(() -> memberService.createMember(duplicateEmail, "password"));
+            Exception exception = catchException(() -> memberService.createMember(request));
 
             //then
             assertThat(exception).isInstanceOf(DuplicateResourceException.class);

--- a/src/test/java/com/thirdparty/ticketing/global/security/BCryptPasswordEncoderTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/BCryptPasswordEncoderTest.java
@@ -1,0 +1,87 @@
+package com.thirdparty.ticketing.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import java.util.NoSuchElementException;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BCryptPasswordEncoderTest {
+
+    private BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+    private static final Pattern BCRYPT_PATTERN
+            = Pattern.compile("\\A\\$2(a|y|b)?\\$(\\d\\d)\\$[./0-9A-Za-z]{53}");
+
+    @Nested
+    @DisplayName("encode 호출 시")
+    class EncodeTest {
+
+        @Test
+        @DisplayName("패스워드를 암호화한다.")
+        void encodePassword() {
+            //given
+            String rawPassword = "password";
+
+            //when
+            String encodedPassword = bCryptPasswordEncoder.encode(rawPassword);
+
+            //then
+            assertThat(encodedPassword).isNotEqualTo(rawPassword);
+        }
+
+        @Test
+        @DisplayName("패스워드를 BCrypt 형식으로 암호화한다.")
+        void encodePassword_UsingBCrypt() {
+            //given
+            String rawPassword = "password";
+
+            //when
+            String encodedPassword = bCryptPasswordEncoder.encode(rawPassword);
+
+            //then
+            assertThat(BCRYPT_PATTERN.matcher(encodedPassword).matches()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("checkPassword 호출 시")
+    class CheckPasswordTest {
+
+        @Test
+        @DisplayName("사용자의 암호화된 패스워드와 입력된 raw 패스워드가 같으면 예외를 던지지 않는다.")
+        void doesNotThrowException_WhenEqualsMemberPasswordAndRawPassword() {
+            //given
+            String rawPassword = "password";
+            Member member = Member.builder()
+                    .password(bCryptPasswordEncoder.encode(rawPassword))
+                    .build();
+
+            //when
+            Exception exception = catchException(() -> bCryptPasswordEncoder.checkMatches(member, rawPassword));
+
+            //then
+            assertThat(exception).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("예외(noSuchElement): 사용자의 암호화된 패스워드와 입력된 raw 패스워드가 같지 않으면")
+        void noSuchElement_WhenNotEqualsMemberPasswordAndRawPassword() {
+            //given
+            String rawPassword = "password";
+            Member member = Member.builder()
+                    .password(bCryptPasswordEncoder.encode(rawPassword))
+                    .build();
+            String wrongPassword = rawPassword + "a";
+
+            //when
+            Exception exception = catchException(() -> bCryptPasswordEncoder.checkMatches(member, wrongPassword));
+
+            //then
+            assertThat(exception).isInstanceOf(NoSuchElementException.class);
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 회원 생성 기능을 구현하였습니다.
  - 이메일 중복 여부 검증 후 회원을 생성하고 저정합니다.
- BCrypt 패스워드 인코더를 구현체를 빈으로 등록했습니다.
  - 프로젝트의 기존 패스워드 인코더 인터페이스를 그대로 사용하고 스프링 시큐리티의 `BCryptPasswordEncoder`를 구현체에서 사용합니다.

### 📝 작업 요약
- 회원 생성 기능 구현
- BCrypt 패스워드 인코더 추가

### 💡 관련 이슈
- close #1 
