### PR TITLE
fix: LoginMember 어노테이션 위치 이동

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/common/LoginMember.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/common/LoginMember.java
@@ -1,4 +1,4 @@
-package com.thirdparty.ticketing.global.security;
+package com.thirdparty.ticketing.domain.common;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/controller/TicketController.java
@@ -9,11 +9,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.thirdparty.ticketing.domain.ItemResult;
+import com.thirdparty.ticketing.domain.common.LoginMember;
 import com.thirdparty.ticketing.domain.ticket.dto.SeatSelectionRequest;
 import com.thirdparty.ticketing.domain.ticket.dto.TicketElement;
 import com.thirdparty.ticketing.domain.ticket.dto.TicketPaymentRequest;
 import com.thirdparty.ticketing.domain.ticket.service.TicketService;
-import com.thirdparty.ticketing.global.security.LoginMember;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolver.java
@@ -9,6 +9,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.LoginMember;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.thirdparty.ticketing.domain.common.LoginMember;
 import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
 import com.thirdparty.ticketing.global.security.LoginMemberArgumentResolverTest.ResolverTestController;


### PR DESCRIPTION
### ⛏ 작업 사항

* domain에서 global에 있는 `LoginMember`라는 어노테이션을 알게 되어서 위치 이동하였음

### 📝 작업 요약


### 💡 관련 이슈
- close #
