### PR TITLE
Refactor: Seat, SeatGrade 엔티티 DDL 오류 수정

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/seat/Seat.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/Seat.java
@@ -28,7 +28,7 @@ public class Seat extends BaseEntity {
     private Zone zone;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "seat_Grade", nullable = false)
+    @JoinColumn(name = "seat_grade_id", nullable = false)
     private SeatGrade seatGrade;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/SeatGrade.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/SeatGrade.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.domain.seat;
 
 import jakarta.persistence.*;
 
+import com.thirdparty.ticketing.domain.BaseEntity;
 import com.thirdparty.ticketing.domain.performance.Performance;
 
 import lombok.*;
@@ -12,7 +13,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SeatGrade {
+public class SeatGrade extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long seatGradeId;


### PR DESCRIPTION
### ⛏ 작업 사항
- Seat 엔티티의 좌석 등급 컬럼 명이 "seat_Grade" 로 설정되어 있는 것을 "seat_grade_id" 로 변경
- SeatGrade 엔티티에 BaseTimeEntity 를 상속받지 않은 부분 수정

### 📝 작업 요약
- Seat, SeatGrade 엔티티 DDL 오류 수정

### 💡 관련 이슈
- close #49 
