### PR TITLE
Feature: 사용자는 남은 대기 순번을 확인할 수 있다. 

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/WaitingController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/WaitingController.java
@@ -1,0 +1,29 @@
+package com.thirdparty.ticketing.domain.waiting;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.thirdparty.ticketing.domain.common.LoginMember;
+import com.thirdparty.ticketing.domain.waiting.manager.WaitingManager;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class WaitingController {
+
+    private final WaitingManager waitingManager;
+
+    @GetMapping("/performances/{performanceId}/wait")
+    public ResponseEntity<Map<String, Long>> getCounts(
+            @LoginMember String email, @PathVariable("performanceId") Long performanceId) {
+        long remainingCount = waitingManager.getRemainingCount(email, performanceId);
+        return ResponseEntity.ok(Map.of("remainingCount", remainingCount));
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/DefaultWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/DefaultWaitingManager.java
@@ -25,6 +25,11 @@ public class DefaultWaitingManager extends WaitingManager {
         return map.get(performanceId);
     }
 
+    @Override
+    public long getRemainingCount(String email, Long performanceId) {
+        return 0;
+    }
+
     public void moveWaitingMemberToRunningRoom(long performanceId, long count) {
         List<WaitingMember> waitingMembers = waitingRoom.pollWaitingMembers(performanceId, count);
         long maxCount = 0L;

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/WaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/WaitingManager.java
@@ -27,4 +27,13 @@ public abstract class WaitingManager {
     }
 
     protected abstract long countManagedMember(WaitingMember waitingMember);
+
+    /**
+     * 사용자의 남은 순번을 조회한다. 남은 순번이 1이하인 경우 이벤트를 발행한다.
+     *
+     * @param email 사용자의 이메일
+     * @param performanceId 공연 대기 정보 조회를 위한 공연 ID
+     * @return 사용자의 남은 순번
+     */
+    public abstract long getRemainingCount(String email, Long performanceId);
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waiting/manager/RedisWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waiting/manager/RedisWaitingManager.java
@@ -27,6 +27,11 @@ public class RedisWaitingManager extends WaitingManager {
         return Long.parseLong(managedMemberCounter.get(key));
     }
 
+    @Override
+    public long getRemainingCount(String email, Long performanceId) {
+        return 0;
+    }
+
     private String getPerformanceManagedMemberCounterKey(WaitingMember waitingMember) {
         return MANAGED_MEMBER_COUNTER_KEY + waitingMember.getPerformanceId();
     }


### PR DESCRIPTION
### ⛏ 작업 사항
- 대기열 페이지에서 폴링을 통해 대기 순번을 조회하는 api를 구현하였습니다.
- `WaitingManager`에 사용자의 공연의 남은 대기 순번 조회를 위한 추상 메서드를 정의하였습니다.

### 📝 작업 요약
- 공연에서 남은 대기 순번 조회 api 구현

### 💡 관련 이슈
- close #59 
