### PR TITLE
Refactor: 대기열 시스템 구조를 개선한다. 

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/DefaultWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/DefaultWaitingManager.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import com.thirdparty.ticketing.domain.waiting.room.RunningRoom;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingRoom;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class DefaultWaitingManager extends WaitingManager {
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/WaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/manager/WaitingManager.java
@@ -2,7 +2,7 @@ package com.thirdparty.ticketing.domain.waiting.manager;
 
 import com.thirdparty.ticketing.domain.waiting.room.RunningRoom;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingRoom;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultRunningRoom.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class DefaultRunningRoom implements RunningRoom {
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultWaitingCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultWaitingCounter.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class DefaultWaitingCounter implements WaitingCounter {
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultWaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultWaitingLine.java
@@ -3,7 +3,7 @@ package com.thirdparty.ticketing.domain.waiting.room;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class DefaultWaitingLine implements WaitingLine {
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/DefaultWaitingRoom.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class DefaultWaitingRoom extends WaitingRoom {
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/RunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/RunningRoom.java
@@ -2,7 +2,7 @@ package com.thirdparty.ticketing.domain.waiting.room;
 
 import java.util.List;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public interface RunningRoom {
     boolean contains(WaitingMember waitingMember);

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/WaitingCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/WaitingCounter.java
@@ -1,6 +1,6 @@
 package com.thirdparty.ticketing.domain.waiting.room;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public interface WaitingCounter {
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/WaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/WaitingLine.java
@@ -2,7 +2,7 @@ package com.thirdparty.ticketing.domain.waiting.room;
 
 import java.util.List;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public interface WaitingLine {
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waiting/room/WaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waiting/room/WaitingRoom.java
@@ -2,7 +2,7 @@ package com.thirdparty.ticketing.domain.waiting.room;
 
 import java.util.List;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/RunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/RunningRoom.java
@@ -1,3 +1,0 @@
-package com.thirdparty.ticketing.domain.waitingsystem;
-
-public interface RunningRoom {}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspect.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspect.java
@@ -1,6 +1,5 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -12,6 +11,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import com.thirdparty.ticketing.domain.waiting.manager.WaitingManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspect.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspect.java
@@ -1,5 +1,6 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingRoom.java
@@ -1,3 +1,0 @@
-package com.thirdparty.ticketing.domain.waitingsystem;
-
-public interface WaitingRoom {}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
@@ -1,5 +1,8 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.util.Set;
 
 import com.thirdparty.ticketing.domain.common.EventPublisher;

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
@@ -1,11 +1,11 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.util.Set;
 
 import com.thirdparty.ticketing.domain.common.EventPublisher;
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningCounter.java
@@ -1,4 +1,3 @@
 package com.thirdparty.ticketing.domain.waitingsystem.running;
 
-public interface RunningCounter {
-}
+public interface RunningCounter {}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningCounter.java
@@ -1,0 +1,4 @@
+package com.thirdparty.ticketing.domain.waitingsystem.running;
+
+public interface RunningCounter {
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
@@ -1,7 +1,8 @@
 package com.thirdparty.ticketing.domain.waitingsystem.running;
 
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.util.Set;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public interface RunningManager {
     boolean isReadyToHandle(String email, long performanceId);

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
@@ -1,5 +1,6 @@
-package com.thirdparty.ticketing.domain.waitingsystem;
+package com.thirdparty.ticketing.domain.waitingsystem.running;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.util.Set;
 
 public interface RunningManager {

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningRoom.java
@@ -1,0 +1,3 @@
+package com.thirdparty.ticketing.domain.waitingsystem.running;
+
+public interface RunningRoom {}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingCounter.java
@@ -1,0 +1,4 @@
+package com.thirdparty.ticketing.domain.waitingsystem.waiting;
+
+public interface WaitingCounter {
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingCounter.java
@@ -1,4 +1,3 @@
 package com.thirdparty.ticketing.domain.waitingsystem.waiting;
 
-public interface WaitingCounter {
-}
+public interface WaitingCounter {}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingLine.java
@@ -1,4 +1,3 @@
 package com.thirdparty.ticketing.domain.waitingsystem.waiting;
 
-public interface WaitingLine {
-}
+public interface WaitingLine {}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingLine.java
@@ -1,0 +1,4 @@
+package com.thirdparty.ticketing.domain.waitingsystem.waiting;
+
+public interface WaitingLine {
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingManager.java
@@ -1,4 +1,4 @@
-package com.thirdparty.ticketing.domain.waitingsystem;
+package com.thirdparty.ticketing.domain.waitingsystem.waiting;
 
 import java.util.Set;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingMember.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingMember.java
@@ -1,4 +1,4 @@
-package com.thirdparty.ticketing.domain.waitingsystem;
+package com.thirdparty.ticketing.domain.waitingsystem.waiting;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingRoom.java
@@ -1,0 +1,3 @@
+package com.thirdparty.ticketing.domain.waitingsystem.waiting;
+
+public interface WaitingRoom {}

--- a/src/main/java/com/thirdparty/ticketing/global/waiting/manager/RedisWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waiting/manager/RedisWaitingManager.java
@@ -6,7 +6,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import com.thirdparty.ticketing.domain.waiting.manager.WaitingManager;
 import com.thirdparty.ticketing.domain.waiting.room.RunningRoom;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingRoom;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class RedisWaitingManager extends WaitingManager {
 

--- a/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisRunningRoom.java
@@ -6,7 +6,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 
 import com.thirdparty.ticketing.domain.waiting.room.RunningRoom;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class RedisRunningRoom implements RunningRoom {
 

--- a/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisWaitingCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisWaitingCounter.java
@@ -4,7 +4,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import com.thirdparty.ticketing.domain.waiting.room.WaitingCounter;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class RedisWaitingCounter implements WaitingCounter {
 

--- a/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisWaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisWaitingLine.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingLine;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.ObjectMapperUtils;
 
 public class RedisWaitingLine implements WaitingLine {

--- a/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waiting/room/RedisWaitingRoom.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingCounter;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingLine;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingRoom;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.ObjectMapperUtils;
 
 public class RedisWaitingRoom extends WaitingRoom {

--- a/src/test/java/com/thirdparty/ticketing/domain/waiting/manager/DefaultWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waiting/manager/DefaultWaitingManagerTest.java
@@ -13,7 +13,7 @@ import com.thirdparty.ticketing.domain.waiting.room.DefaultRunningRoom;
 import com.thirdparty.ticketing.domain.waiting.room.DefaultWaitingCounter;
 import com.thirdparty.ticketing.domain.waiting.room.DefaultWaitingLine;
 import com.thirdparty.ticketing.domain.waiting.room.DefaultWaitingRoom;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 class DefaultWaitingManagerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waiting/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waiting/RedisRunningRoomTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.room.RedisRunningRoom;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingCounterTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingCounter;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingLineTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingLineTest.java
@@ -19,7 +19,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingLine;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingManagerTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.manager.RedisWaitingManager;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waiting/RedisWaitingRoomTest.java
@@ -21,7 +21,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingRoom;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 대기열 시스템 구조를 다음 그림의 3-1.과 같이 개선했습니다.
  - `WaitingRoom`이 가지는 대기열, 대기 번호 발급, 대기열 입장 정보 관리의 책임을 다시 `WaitingLine`, `WaitingCounter`, `WaitingRoom` 인터페이스로 분리했습니다.
  - `RunningRoom`이 가지는 작업 가능 공간 입장 정보 관리, 작업 가능 공간 입장 카운터의 책임을 다시 `RunningRoom`, `RunningCounter` 인터페이스로 분리했습니다.

![레디스 대기열 시스템](https://github.com/user-attachments/assets/db010201-791e-45be-ad1a-d5aee8a375d1)


### 📝 작업 요약
- 대기열 시스템 구조 개선

### 💡 관련 이슈
- close #82 
