### PR TITLE
Feature: 사용자의 남은 대기 순번을 레디스에서 조회한다. 

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/common/ErrorCode.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/common/ErrorCode.java
@@ -59,7 +59,7 @@ public enum ErrorCode {
     */
     WAITING_WRITE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "W500-1", "대기열 쓰기에 실패했습니다."),
     WAITING_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "W500-2", "대기열 읽기에 실패했습니다."),
-    ;
+    NOT_FOUND_WAITING_MEMBER(HttpStatus.NOT_FOUND, "W404-1", "대기열에 회원이 존재하지 않습니다.");
 
     ErrorCode(HttpStatus httpStatus, String code, String message) {
         this.httpStatus = httpStatus;

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounter.java
@@ -1,8 +1,9 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningCounter;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningCounter;
 
 public class RedisRunningCounter implements RunningCounter {
 

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounter.java
@@ -1,0 +1,27 @@
+package com.thirdparty.ticketing.global.waitingsystem.redis.running;
+
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningCounter;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+public class RedisRunningCounter implements RunningCounter {
+
+    private static final String RUNNING_COUNTER = "running_counter:";
+
+    private final ValueOperations<String, String> runningCounter;
+
+    public RedisRunningCounter(StringRedisTemplate redisTemplate) {
+        this.runningCounter = redisTemplate.opsForValue();
+    }
+
+    public long getRunningCount(long performanceId) {
+        String key = getRunningCounterKey(performanceId);
+        runningCounter.setIfAbsent(key, "0");
+        String rawRunningCount = runningCounter.get(key);
+        return Long.parseLong(rawRunningCount);
+    }
+
+    private String getRunningCounterKey(long performanceId) {
+        return RUNNING_COUNTER + performanceId;
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 public class RedisRunningManager implements RunningManager {
 
     private final RedisRunningRoom runningRoom;
+    private final RedisRunningCounter runningCounter;
 
     @Override
     public boolean isReadyToHandle(String email, long performanceId) {
@@ -19,7 +20,7 @@ public class RedisRunningManager implements RunningManager {
 
     @Override
     public long getRunningCount(long performanceId) {
-        return 0;
+        return runningCounter.getRunningCount(performanceId);
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
@@ -1,5 +1,7 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
@@ -30,7 +32,8 @@ public class RedisWaitingManager implements WaitingManager {
 
     @Override
     public WaitingMember findWaitingMember(String email, long performanceId) {
-        return null;
+        return waitingRoom.findWaitingMember(email, performanceId)
+                .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_WAITING_MEMBER));
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
@@ -1,10 +1,10 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
-import com.thirdparty.ticketing.domain.common.ErrorCode;
-import com.thirdparty.ticketing.domain.common.TicketingException;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
@@ -32,7 +32,8 @@ public class RedisWaitingManager implements WaitingManager {
 
     @Override
     public WaitingMember findWaitingMember(String email, long performanceId) {
-        return waitingRoom.findWaitingMember(email, performanceId)
+        return waitingRoom
+                .findWaitingMember(email, performanceId)
                 .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_WAITING_MEMBER));
     }
 

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
@@ -1,5 +1,6 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
+import java.util.Optional;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -34,5 +35,10 @@ public class RedisWaitingRoom implements WaitingRoom {
 
     private String getWaitingRoomKey(long performanceId) {
         return WAITING_ROOM_KEY + performanceId;
+    }
+
+    public Optional<WaitingMember> findWaitingMember(String email, long performanceId) {
+        return Optional.ofNullable(waitingRoom.get(getWaitingRoomKey(performanceId), email))
+                .map(waitingMember -> ObjectMapperUtils.readValue(objectMapper, waitingMember, WaitingMember.class));
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
@@ -1,6 +1,7 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import java.util.Optional;
+
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -39,6 +40,9 @@ public class RedisWaitingRoom implements WaitingRoom {
 
     public Optional<WaitingMember> findWaitingMember(String email, long performanceId) {
         return Optional.ofNullable(waitingRoom.get(getWaitingRoomKey(performanceId), email))
-                .map(waitingMember -> ObjectMapperUtils.readValue(objectMapper, waitingMember, WaitingMember.class));
+                .map(
+                        waitingMember ->
+                                ObjectMapperUtils.readValue(
+                                        objectMapper, waitingMember, WaitingMember.class));
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -1,0 +1,98 @@
+package com.thirdparty.ticketing.domain.waitingsystem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
+import com.thirdparty.ticketing.support.SpyEventPublisher;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootTest
+@Import(TestRedisConfig.class)
+class WaitingSystemTest extends TestContainerStarter {
+
+    private WaitingSystem waitingSystem;
+
+    @Autowired
+    private WaitingManager waitingManager;
+
+    @Autowired
+    private RunningManager runningManager;
+
+    private SpyEventPublisher eventPublisher;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private ValueOperations<String, String> rawRunningCounter;
+
+    @BeforeEach
+    void setUp() {
+        rawRunningCounter = redisTemplate.opsForValue();
+        eventPublisher = new SpyEventPublisher();
+        waitingSystem = new WaitingSystem(waitingManager, runningManager, eventPublisher);
+        redisTemplate.getConnectionFactory()
+                .getConnection()
+                .serverCommands()
+                .flushAll();
+    }
+
+    private String getRunningCounterKey(long performanceId) {
+        return "running_counter:" + performanceId;
+    }
+
+    @Nested
+    @DisplayName("사용자의 남은 순번 조회 시")
+    class GetRemainingCountTest {
+
+        @ParameterizedTest
+        @CsvSource({
+                "0, 0, 1",
+                "15, 10, 6"
+        })
+        @DisplayName("자신이 몇 번째 차례인지 반환한다.")
+        void getRemainingCount(int waitingCount, String runningCount, int expected) {
+            //given
+            long performanceId = 1;
+            for(int i = 0; i < waitingCount; i++) {
+                waitingSystem.enterWaitingRoom("email" + i + "@email.com", performanceId);
+            }
+            String email = "email@email.com";
+            waitingSystem.enterWaitingRoom(email, performanceId);
+            rawRunningCounter.set(getRunningCounterKey(performanceId), runningCount);
+
+            //when
+            long remainingCount = waitingSystem.getRemainingCount(email, performanceId);
+
+            //then
+            assertThat(remainingCount).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("폴링 이벤트를 발행한다.")
+        void publishPollingEvent() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            waitingSystem.enterWaitingRoom(email, performanceId);
+
+            //when
+            waitingSystem.getRemainingCount(email, performanceId);
+
+            //then
+            assertThat(eventPublisher.counter).hasValue(1);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/waiting/TestRedisConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waiting/TestRedisConfig.java
@@ -1,5 +1,10 @@
 package com.thirdparty.ticketing.global.waiting;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.waiting.room.RunningRoom;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingCounter;
@@ -10,10 +15,6 @@ import com.thirdparty.ticketing.global.waiting.room.RedisRunningRoom;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingCounter;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingLine;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingRoom;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.core.StringRedisTemplate;
 
 @TestConfiguration
 public class TestRedisConfig {

--- a/src/test/java/com/thirdparty/ticketing/global/waiting/TestRedisConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waiting/TestRedisConfig.java
@@ -1,10 +1,5 @@
 package com.thirdparty.ticketing.global.waiting;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.core.StringRedisTemplate;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.waiting.room.RunningRoom;
 import com.thirdparty.ticketing.domain.waiting.room.WaitingCounter;
@@ -15,6 +10,10 @@ import com.thirdparty.ticketing.global.waiting.room.RedisRunningRoom;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingCounter;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingLine;
 import com.thirdparty.ticketing.global.waiting.room.RedisWaitingRoom;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @TestConfiguration
 public class TestRedisConfig {

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
@@ -1,5 +1,7 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis;
 
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningCounter;
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -15,9 +17,11 @@ import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingR
 @TestConfiguration
 public class TestRedisConfig {
 
-    @Autowired private StringRedisTemplate redisTemplate;
+    @Autowired
+    private StringRedisTemplate redisTemplate;
 
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Bean
     public RedisWaitingManager waitingManager(
@@ -43,7 +47,19 @@ public class TestRedisConfig {
     }
 
     @Bean
+    public RedisRunningManager runningManager(
+            RedisRunningRoom runningRoom,
+            RedisRunningCounter runningCounter) {
+        return new RedisRunningManager(runningRoom, runningCounter);
+    }
+
+    @Bean
     public RedisRunningRoom runningRoom() {
         return new RedisRunningRoom(redisTemplate);
+    }
+
+    @Bean
+    public RedisRunningCounter runningCounter() {
+        return new RedisRunningCounter(redisTemplate);
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
@@ -1,13 +1,13 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis;
 
-import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningCounter;
-import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningCounter;
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningManager;
 import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
 import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingCounter;
 import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingLine;
@@ -17,11 +17,9 @@ import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingR
 @TestConfiguration
 public class TestRedisConfig {
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+    @Autowired private StringRedisTemplate redisTemplate;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    @Autowired private ObjectMapper objectMapper;
 
     @Bean
     public RedisWaitingManager waitingManager(
@@ -48,8 +46,7 @@ public class TestRedisConfig {
 
     @Bean
     public RedisRunningManager runningManager(
-            RedisRunningRoom runningRoom,
-            RedisRunningCounter runningCounter) {
+            RedisRunningRoom runningRoom, RedisRunningCounter runningCounter) {
         return new RedisRunningManager(runningRoom, runningCounter);
     }
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
@@ -1,0 +1,92 @@
+package com.thirdparty.ticketing.global.waitingsystem.redis.running;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootTest
+@Import(TestRedisConfig.class)
+class RedisRunningCounterTest extends TestContainerStarter {
+
+    @Autowired
+    private RedisRunningCounter runningCounter;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private ValueOperations<String, String> rawRunningCounter;
+
+    @BeforeEach
+    void setUp() {
+        rawRunningCounter = redisTemplate.opsForValue();
+        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    private String getRunningCounterKey(long performanceId) {
+        return "running_counter:" + performanceId;
+    }
+
+    @Nested
+    @DisplayName("작업 대기 공간으로 이동한 인원 수 조회 시")
+    class GetRunningCountTest {
+
+        @Test
+        @DisplayName("카운터가 초기화되지 않았다면 0으로 초기화한다.")
+        void initializeCounter() {
+            //given
+            long performanceId = 1;
+
+            //when
+            long runningCount = runningCounter.getRunningCount(performanceId);
+
+            //then
+            assertThat(runningCount).isEqualTo(0);
+        }
+
+        @RepeatedTest(5)
+        @DisplayName("카운터가 초기화되었다면 0으로 초기화하지 않는다.")
+        void doNotReInitializeCounter() throws InterruptedException, ExecutionException {
+            //given
+            long performanceId = 1;
+            int poolSize = 50;
+            ExecutorService executorService = Executors.newFixedThreadPool(poolSize);
+            CountDownLatch latch = new CountDownLatch(poolSize);
+
+            //when
+            for(int i=0; i<poolSize; i++) {
+                int finalI = i;
+                executorService.execute(() -> {
+                    try {
+                        if (finalI % 2 == 0) {
+                            rawRunningCounter.set(getRunningCounterKey(performanceId), "10");
+                        } else {
+                            runningCounter.getRunningCount(performanceId);
+                        }
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            //then
+            long runningCount = runningCounter.getRunningCount(performanceId);
+            assertThat(runningCount).isEqualTo(10);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
@@ -2,12 +2,11 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,15 +18,16 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
+import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+
 @SpringBootTest
 @Import(TestRedisConfig.class)
 class RedisRunningCounterTest extends TestContainerStarter {
 
-    @Autowired
-    private RedisRunningCounter runningCounter;
+    @Autowired private RedisRunningCounter runningCounter;
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+    @Autowired private StringRedisTemplate redisTemplate;
 
     private ValueOperations<String, String> rawRunningCounter;
 
@@ -48,43 +48,45 @@ class RedisRunningCounterTest extends TestContainerStarter {
         @Test
         @DisplayName("카운터가 초기화되지 않았다면 0으로 초기화한다.")
         void initializeCounter() {
-            //given
+            // given
             long performanceId = 1;
 
-            //when
+            // when
             long runningCount = runningCounter.getRunningCount(performanceId);
 
-            //then
+            // then
             assertThat(runningCount).isEqualTo(0);
         }
 
         @RepeatedTest(5)
         @DisplayName("카운터가 초기화되었다면 0으로 초기화하지 않는다.")
         void doNotReInitializeCounter() throws InterruptedException, ExecutionException {
-            //given
+            // given
             long performanceId = 1;
             int poolSize = 50;
             ExecutorService executorService = Executors.newFixedThreadPool(poolSize);
             CountDownLatch latch = new CountDownLatch(poolSize);
 
-            //when
-            for(int i=0; i<poolSize; i++) {
+            // when
+            for (int i = 0; i < poolSize; i++) {
                 int finalI = i;
-                executorService.execute(() -> {
-                    try {
-                        if (finalI % 2 == 0) {
-                            rawRunningCounter.set(getRunningCounterKey(performanceId), "10");
-                        } else {
-                            runningCounter.getRunningCount(performanceId);
-                        }
-                    } finally {
-                        latch.countDown();
-                    }
-                });
+                executorService.execute(
+                        () -> {
+                            try {
+                                if (finalI % 2 == 0) {
+                                    rawRunningCounter.set(
+                                            getRunningCounterKey(performanceId), "10");
+                                } else {
+                                    runningCounter.getRunningCount(performanceId);
+                                }
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
             }
             latch.await();
 
-            //then
+            // then
             long runningCount = runningCounter.getRunningCount(performanceId);
             assertThat(runningCount).isEqualTo(10);
         }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
@@ -1,0 +1,73 @@
+package com.thirdparty.ticketing.global.waitingsystem.redis.running;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootTest
+@Import(TestRedisConfig.class)
+class RedisRunningManagerTest extends TestContainerStarter {
+
+    @Autowired
+    private RedisRunningManager runningManager;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private ValueOperations<String, String> rawRunningCounter;
+
+    @BeforeEach
+    void setUp() {
+        rawRunningCounter = redisTemplate.opsForValue();
+        redisTemplate.getConnectionFactory()
+                .getConnection()
+                .serverCommands()
+                .flushAll();
+    }
+
+    private String getRunningCounterKey(long performanceId) {
+        return "running_counter:" + performanceId;
+    }
+
+    @Nested
+    @DisplayName("러닝 카운트 조회 시")
+    class GetRunningCountTest {
+
+        @Test
+        @DisplayName("작업 가능 공간으로 진입한 인원 수를 반환한다.")
+        void getRunningCount() {
+            //given
+            long performanceId = 1;
+            rawRunningCounter.setIfAbsent(getRunningCounterKey(performanceId), "23");
+
+            //when
+            long runningCount = runningManager.getRunningCount(performanceId);
+
+            //then
+            assertThat(runningCount).isEqualTo(23);
+        }
+
+        @Test
+        @DisplayName("카운트가 존재하지 않으면 0부터 시작한다.")
+        void startCounterWithZeroValue() {
+            //given
+            long performanceId = 1;
+
+            //when
+            long runningCount = runningManager.getRunningCount(performanceId);
+
+            //then
+            assertThat(runningCount).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
@@ -2,8 +2,6 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,25 +12,23 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
+import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+
 @SpringBootTest
 @Import(TestRedisConfig.class)
 class RedisRunningManagerTest extends TestContainerStarter {
 
-    @Autowired
-    private RedisRunningManager runningManager;
+    @Autowired private RedisRunningManager runningManager;
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+    @Autowired private StringRedisTemplate redisTemplate;
 
     private ValueOperations<String, String> rawRunningCounter;
 
     @BeforeEach
     void setUp() {
         rawRunningCounter = redisTemplate.opsForValue();
-        redisTemplate.getConnectionFactory()
-                .getConnection()
-                .serverCommands()
-                .flushAll();
+        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
     private String getRunningCounterKey(long performanceId) {
@@ -46,27 +42,27 @@ class RedisRunningManagerTest extends TestContainerStarter {
         @Test
         @DisplayName("작업 가능 공간으로 진입한 인원 수를 반환한다.")
         void getRunningCount() {
-            //given
+            // given
             long performanceId = 1;
             rawRunningCounter.setIfAbsent(getRunningCounterKey(performanceId), "23");
 
-            //when
+            // when
             long runningCount = runningManager.getRunningCount(performanceId);
 
-            //then
+            // then
             assertThat(runningCount).isEqualTo(23);
         }
 
         @Test
         @DisplayName("카운트가 존재하지 않으면 0부터 시작한다.")
         void startCounterWithZeroValue() {
-            //given
+            // given
             long performanceId = 1;
 
-            //when
+            // when
             long runningCount = runningManager.getRunningCount(performanceId);
 
-            //then
+            // then
             assertThat(runningCount).isEqualTo(0);
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
@@ -3,8 +3,6 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.thirdparty.ticketing.domain.common.ErrorCode;
-import com.thirdparty.ticketing.domain.common.TicketingException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -24,6 +22,8 @@ import org.springframework.data.redis.core.ZSetOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waiting.ObjectMapperUtils;
 import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
@@ -33,14 +33,11 @@ import com.thirdparty.ticketing.support.TestContainerStarter;
 @Import(TestRedisConfig.class)
 class RedisWaitingManagerTest extends TestContainerStarter {
 
-    @Autowired
-    private RedisWaitingManager waitingManager;
+    @Autowired private RedisWaitingManager waitingManager;
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+    @Autowired private StringRedisTemplate redisTemplate;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    @Autowired private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
@@ -168,15 +165,15 @@ class RedisWaitingManagerTest extends TestContainerStarter {
         @Test
         @DisplayName("사용자가 존재하면 반환한다.")
         void returnWaitingMember() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             waitingManager.enterWaitingRoom(email, performanceId);
 
-            //when
+            // when
             WaitingMember waitingMember = waitingManager.findWaitingMember(email, performanceId);
 
-            //then
+            // then
             assertThat(waitingMember.getEmail()).isEqualTo(email);
             assertThat(waitingMember.getPerformanceId()).isEqualTo(performanceId);
         }
@@ -184,20 +181,22 @@ class RedisWaitingManagerTest extends TestContainerStarter {
         @Test
         @DisplayName("예외(NOT_FOUND_WAITING_MEMBER): 사용자가 존재하지 않으면")
         void notFoundWaitingMember() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
 
-            //when
-            Exception exception = catchException(
-                    () -> waitingManager.findWaitingMember(email, performanceId));
+            // when
+            Exception exception =
+                    catchException(() -> waitingManager.findWaitingMember(email, performanceId));
 
-            //then
-            assertThat(exception).isInstanceOf(TicketingException.class)
+            // then
+            assertThat(exception)
+                    .isInstanceOf(TicketingException.class)
                     .extracting(e -> ((TicketingException) e).getErrorCode())
-                    .satisfies(errorCode -> {
-                        assertThat(errorCode).isEqualTo(ErrorCode.NOT_FOUND_WAITING_MEMBER);
-                    });
+                    .satisfies(
+                            errorCode -> {
+                                assertThat(errorCode).isEqualTo(ErrorCode.NOT_FOUND_WAITING_MEMBER);
+                            });
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
@@ -121,35 +121,41 @@ class RedisWaitingRoomTest extends TestContainerStarter {
         @Test
         @DisplayName("사용자가 존재하면 반환한다.")
         void returnWaitingMember() {
-            //given
+            // given
             String email = "email@email.com";
             long performanceId = 1;
             waitingRoom.enter(email, performanceId);
-            waitingRoom.updateMemberInfo(new WaitingMember(email, performanceId, 1, ZonedDateTime.now()));
+            waitingRoom.updateMemberInfo(
+                    new WaitingMember(email, performanceId, 1, ZonedDateTime.now()));
 
-            //when
-            Optional<WaitingMember> optionalWaitingMember = waitingRoom.findWaitingMember(email, performanceId);
+            // when
+            Optional<WaitingMember> optionalWaitingMember =
+                    waitingRoom.findWaitingMember(email, performanceId);
 
-            //then
-            assertThat(optionalWaitingMember).isNotEmpty()
+            // then
+            assertThat(optionalWaitingMember)
+                    .isNotEmpty()
                     .get()
-                    .satisfies(waitingMember -> {
-                        assertThat(waitingMember.getEmail()).isEqualTo(email);
-                        assertThat(waitingMember.getPerformanceId()).isEqualTo(performanceId);
-                    });
+                    .satisfies(
+                            waitingMember -> {
+                                assertThat(waitingMember.getEmail()).isEqualTo(email);
+                                assertThat(waitingMember.getPerformanceId())
+                                        .isEqualTo(performanceId);
+                            });
         }
 
         @Test
         @DisplayName("사용자가 존재하지 않으면 빈 값을 반환한다.")
         void returnEmpty() {
-            //given
+            // given
             String email = "email@email.com";
             long performanceId = 1;
 
-            //when
-            Optional<WaitingMember> optionalWaitingMember = waitingRoom.findWaitingMember(email, performanceId);
+            // when
+            Optional<WaitingMember> optionalWaitingMember =
+                    waitingRoom.findWaitingMember(email, performanceId);
 
-            //then
+            // then
             assertThat(optionalWaitingMember).isEmpty();
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
@@ -113,4 +113,44 @@ class RedisWaitingRoomTest extends TestContainerStarter {
                             });
         }
     }
+
+    @Nested
+    @DisplayName("대기 중인 사용자 조회 시")
+    class FindWaitingMemberTest {
+
+        @Test
+        @DisplayName("사용자가 존재하면 반환한다.")
+        void returnWaitingMember() {
+            //given
+            String email = "email@email.com";
+            long performanceId = 1;
+            waitingRoom.enter(email, performanceId);
+            waitingRoom.updateMemberInfo(new WaitingMember(email, performanceId, 1, ZonedDateTime.now()));
+
+            //when
+            Optional<WaitingMember> optionalWaitingMember = waitingRoom.findWaitingMember(email, performanceId);
+
+            //then
+            assertThat(optionalWaitingMember).isNotEmpty()
+                    .get()
+                    .satisfies(waitingMember -> {
+                        assertThat(waitingMember.getEmail()).isEqualTo(email);
+                        assertThat(waitingMember.getPerformanceId()).isEqualTo(performanceId);
+                    });
+        }
+
+        @Test
+        @DisplayName("사용자가 존재하지 않으면 빈 값을 반환한다.")
+        void returnEmpty() {
+            //given
+            String email = "email@email.com";
+            long performanceId = 1;
+
+            //when
+            Optional<WaitingMember> optionalWaitingMember = waitingRoom.findWaitingMember(email, performanceId);
+
+            //then
+            assertThat(optionalWaitingMember).isEmpty();
+        }
+    }
 }

--- a/src/test/java/com/thirdparty/ticketing/support/SpyEventPublisher.java
+++ b/src/test/java/com/thirdparty/ticketing/support/SpyEventPublisher.java
@@ -1,8 +1,9 @@
 package com.thirdparty.ticketing.support;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import com.thirdparty.ticketing.domain.common.Event;
 import com.thirdparty.ticketing.domain.common.EventPublisher;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class SpyEventPublisher implements EventPublisher {
 

--- a/src/test/java/com/thirdparty/ticketing/support/SpyEventPublisher.java
+++ b/src/test/java/com/thirdparty/ticketing/support/SpyEventPublisher.java
@@ -1,0 +1,15 @@
+package com.thirdparty.ticketing.support;
+
+import com.thirdparty.ticketing.domain.common.Event;
+import com.thirdparty.ticketing.domain.common.EventPublisher;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SpyEventPublisher implements EventPublisher {
+
+    public AtomicInteger counter = new AtomicInteger(0);
+
+    @Override
+    public void publish(Event event) {
+        counter.incrementAndGet();
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 대기열 시스템의 사용자 남은 순번 조회 기능을 구현했습니다.
  - `WaitingRoom`으로 부터 대기중인 사용자 정보를 조회합니다.
  - `RunningCounter`로부터 대기열에서 작업 가능 공간으로 이동한 인원수(`runningCount`)를 조회합니다.
  - 대기중인 사용자 정보 `WaitingMember`에서 고유 대기 번호 `waitingCount` 필드에서 `runningCount`를 뺀 값을 사용자에게 반환합니다.
  - 로직의 중간에 폴링 이벤트를 발행합니다. 해당 이벤트는 대기열에서 사용자를 꺼내 작업 가능 공간으로 옮기기 위해 사용할 예정입니다.

### 📝 작업 요약
- 대기열 시스템 사용자 남은 순번 조회 기능 구현

### 💡 관련 이슈
- close #72 
