### PR TITLE
Feature: 사용자를 메모리 대기열에 삽입한다.

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
@@ -1,6 +1,6 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.running;
 
-import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 
 import com.thirdparty.ticketing.domain.waitingsystem.running.RunningRoom;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemoryRunningRoom implements RunningRoom {
 
-    private final Map<Long, Map<String, WaitingMember>> map;
+    private final ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> map;
 
     public boolean contains(String email, long performanceId) {
         if (!map.containsKey(performanceId)) {

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingCounter.java
@@ -1,0 +1,18 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingCounter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemoryWaitingCounter implements WaitingCounter {
+
+    private final Map<Long, AtomicLong> counter;
+
+    public long getNextCount(long performanceId) {
+        return counter.computeIfAbsent(performanceId, k -> new AtomicLong()).incrementAndGet();
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingCounter.java
@@ -1,6 +1,6 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 
-import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingCounter;
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemoryWaitingCounter implements WaitingCounter {
 
-    private final Map<Long, AtomicLong> counter;
+    private final ConcurrentMap<Long, AtomicLong> counter;
 
     public long getNextCount(long performanceId) {
         return counter.computeIfAbsent(performanceId, k -> new AtomicLong()).incrementAndGet();

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLine.java
@@ -1,7 +1,7 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingLine;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemoryWaitingLine implements WaitingLine {
 
-    private final Map<Long, ConcurrentLinkedQueue<WaitingMember>> line;
+    private final ConcurrentMap<Long, ConcurrentLinkedQueue<WaitingMember>> line;
 
     public void enter(WaitingMember waitingMember) {
         line.computeIfAbsent(waitingMember.getPerformanceId(), k -> new ConcurrentLinkedQueue<>())

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLine.java
@@ -1,0 +1,20 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingLine;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemoryWaitingLine implements WaitingLine {
+
+    private final Map<Long, ConcurrentLinkedQueue<WaitingMember>> line;
+
+    public void enter(WaitingMember waitingMember) {
+        line.computeIfAbsent(waitingMember.getPerformanceId(), k -> new ConcurrentLinkedQueue<>())
+                .offer(waitingMember);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
@@ -1,0 +1,38 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import java.time.ZonedDateTime;
+import java.util.Set;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemoryWaitingManager implements WaitingManager {
+
+    private final MemoryWaitingRoom waitingRoom;
+    private final MemoryWaitingCounter waitingCounter;
+    private final MemoryWaitingLine waitingLine;
+
+    @Override
+    public void enterWaitingRoom(String email, long performanceId) {
+        if (waitingRoom.enter(email, performanceId)) {
+            long waitingCount = waitingCounter.getNextCount(performanceId);
+            WaitingMember waitingMember =
+                    new WaitingMember(email, performanceId, waitingCount, ZonedDateTime.now());
+            waitingRoom.updateMemberInfo(waitingMember);
+            waitingLine.enter(waitingMember);
+        }
+    }
+
+    @Override
+    public WaitingMember findWaitingMember(String email, long performanceId) {
+        return null;
+    }
+
+    @Override
+    public Set<WaitingMember> pullOutMembers(long performanceId, long availableToRunning) {
+        return Set.of();
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
@@ -1,0 +1,27 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingRoom;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemoryWaitingRoom implements WaitingRoom {
+
+    private final Map<Long, ConcurrentMap<String, WaitingMember>> room;
+
+    public boolean enter(String email, long performanceId) {
+        return room.computeIfAbsent(performanceId, k -> new ConcurrentHashMap<>())
+                        .putIfAbsent(email, new WaitingMember(email, performanceId))
+                == null;
+    }
+
+    public void updateMemberInfo(WaitingMember waitingMember) {
+        room.computeIfAbsent(waitingMember.getPerformanceId(), k -> new ConcurrentHashMap<>())
+                .put(waitingMember.getEmail(), waitingMember);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
@@ -1,6 +1,5 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -12,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemoryWaitingRoom implements WaitingRoom {
 
-    private final Map<Long, ConcurrentMap<String, WaitingMember>> room;
+    private final ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> room;
 
     public boolean enter(String email, long performanceId) {
         return room.computeIfAbsent(performanceId, k -> new ConcurrentHashMap<>())

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
@@ -2,9 +2,8 @@ package com.thirdparty.ticketing.global.waitingsystem.memory.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,12 +20,12 @@ class MemoryRunningRoomTest {
     @DisplayName("러닝 룸에 사용자가 있는지 확인했을 때")
     class ContainTest {
 
-        private Map<Long, Map<String, WaitingMember>> map;
+        private ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> room;
 
         @BeforeEach
         void setUp() {
-            map = new HashMap<>();
-            runningRoom = new MemoryRunningRoom(map);
+            room = new ConcurrentHashMap<>();
+            runningRoom = new MemoryRunningRoom(room);
         }
 
         @Test
@@ -35,8 +34,8 @@ class MemoryRunningRoomTest {
             // given
             long performanceId = 1;
             String email = "email@email.com";
-            map.putIfAbsent(performanceId, new ConcurrentHashMap<>());
-            map.get(performanceId).putIfAbsent(email, new WaitingMember());
+            room.putIfAbsent(performanceId, new ConcurrentHashMap<>());
+            room.get(performanceId).putIfAbsent(email, new WaitingMember());
 
             // when
             boolean contains = runningRoom.contains(email, performanceId);
@@ -66,8 +65,8 @@ class MemoryRunningRoomTest {
             long performanceIdA = 1;
             long performanceIdB = 2;
             String email = "email@email.com";
-            map.putIfAbsent(performanceIdA, new ConcurrentHashMap<>());
-            map.get(performanceIdA).putIfAbsent(email, new WaitingMember());
+            room.putIfAbsent(performanceIdA, new ConcurrentHashMap<>());
+            room.get(performanceIdA).putIfAbsent(email, new WaitingMember());
 
             // when
             boolean contains = runningRoom.contains(email, performanceIdB);

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingCounterTest.java
@@ -1,0 +1,95 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MemoryWaitingCounterTest {
+
+    private MemoryWaitingCounter waitingCounter;
+
+    @Nested
+    @DisplayName("다음 대기 순번 조회 시")
+    class GetNextCountTest {
+
+        @BeforeEach
+        void setUp() {
+            ConcurrentMap<Long, AtomicLong> counter = new ConcurrentHashMap<>();
+            waitingCounter = new MemoryWaitingCounter(counter);
+        }
+
+        @Test
+        @DisplayName("순번을 조회한다.")
+        void getCount() {
+            // given
+            long performanceId = 1L;
+
+            // when
+            long nextCount = waitingCounter.getNextCount(performanceId);
+
+            // then
+            assertThat(nextCount).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("동시 요청 상황에서 순번을 순차적으로 조회한다.")
+        void getCountIncrement() throws InterruptedException {
+            // given
+            long performanceId = 1L;
+
+            int poolSize = 50;
+            CountDownLatch latch = new CountDownLatch(poolSize);
+            ExecutorService executorService = Executors.newFixedThreadPool(poolSize);
+
+            // when
+            for (int i = 0; i < poolSize; i++) {
+                int finalI = i;
+                executorService.execute(
+                        () -> {
+                            try {
+                                String email = "email" + finalI + "@email.com";
+                                waitingCounter.getNextCount(performanceId);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
+            }
+            latch.await();
+
+            // then
+            assertThat(waitingCounter.getNextCount(performanceId)).isEqualTo(poolSize + 1);
+        }
+
+        @Test
+        @DisplayName("각 공연은 대기 순번을 공유하지 않는다.")
+        void noShareWaitingCounter() {
+            // given
+            long performanceId = 1L;
+            int count = 5;
+            for (int i = 0; i < count; i++) {
+                waitingCounter.getNextCount(performanceId);
+            }
+
+            long performanceId2 = 2L;
+            int count2 = 10;
+            for (int i = 0; i < count2; i++) {
+                waitingCounter.getNextCount(performanceId2);
+            }
+
+            // when
+            long performanceANextCount = waitingCounter.getNextCount(performanceId);
+            long performanceBNextCount = waitingCounter.getNextCount(performanceId2);
+
+            // then
+            assertThat(performanceANextCount).isNotEqualTo(performanceBNextCount);
+            assertThat(performanceANextCount).isEqualTo(count + 1);
+            assertThat(performanceBNextCount).isEqualTo(count2 + 1);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLineTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLineTest.java
@@ -1,0 +1,118 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+
+class MemoryWaitingLineTest {
+
+    private MemoryWaitingLine waitingLine;
+
+    @Nested
+    @DisplayName("대기열 입장 시")
+    class EnterTest {
+
+        private ConcurrentMap<Long, ConcurrentLinkedQueue<WaitingMember>> line;
+
+        @BeforeEach
+        void setUp() {
+            line = new ConcurrentHashMap<>();
+            waitingLine = new MemoryWaitingLine(line);
+        }
+
+        @Test
+        @DisplayName("사용자를 대기열에 추가한다.")
+        void addWaitingLine() {
+            // given
+            long performanceId = 1;
+            long waitingCounter = 1;
+            WaitingMember waitingMember = new WaitingMember("email@email.com", performanceId);
+            waitingMember.updateWaitingInfo(waitingCounter, ZonedDateTime.now());
+
+            // when
+            waitingLine.enter(waitingMember);
+
+            // then
+            assertThat(line.get(performanceId).size()).isEqualTo(1);
+            assertThat(line.get(performanceId).poll()).isEqualTo(waitingMember);
+        }
+
+        @Test
+        @DisplayName("사용자를 순차적으로 대기열에 추가한다.")
+        void addWaitingLineSequentially() {
+            // given
+            long performanceId = 1;
+            List<WaitingMember> waitingMembers = new ArrayList<>();
+            int waitingCounter = 5;
+            for (int i = 0; i < waitingCounter; i++) {
+                waitingMembers.add(new WaitingMember("email" + i + "@email.com", performanceId));
+            }
+
+            // when
+            for (int i = 0; i < waitingCounter; i++) {
+                WaitingMember waitingMember = waitingMembers.get(i);
+                waitingMember.updateWaitingInfo(i, ZonedDateTime.now());
+                waitingLine.enter(waitingMember);
+            }
+
+            // then
+            List<WaitingMember> result = new ArrayList<>();
+            for (int i = 0; i < waitingCounter; i++) {
+                result.add(line.get(performanceId).poll());
+            }
+            assertThat(result.size()).isEqualTo(waitingCounter);
+            assertThat(result).isEqualTo(waitingMembers);
+        }
+
+        @Test
+        @DisplayName("서로 다른 공연은 같은 대기열을 공유하지 않는다.")
+        void notSharedWaitingLine() {
+            // given
+            long performanceAId = 1;
+            int performanceAWaitedMemberCount = 5;
+            long performanceBId = 2;
+            int performanceBWaitedMemberCount = 10;
+
+            // when
+            for (int i = 0; i < performanceAWaitedMemberCount; i++) {
+                WaitingMember waitingMember =
+                        new WaitingMember("email" + i + "@email.com", performanceAId);
+                waitingMember.updateWaitingInfo(i, ZonedDateTime.now());
+                waitingLine.enter(waitingMember);
+            }
+
+            for (int i = 0; i < performanceBWaitedMemberCount; i++) {
+                WaitingMember waitingMember =
+                        new WaitingMember("email" + i + "@email.com", performanceBId);
+                waitingMember.updateWaitingInfo(i, ZonedDateTime.now());
+                waitingLine.enter(waitingMember);
+            }
+
+            // then
+            List<WaitingMember> resultA = new ArrayList<>();
+            List<WaitingMember> resultB = new ArrayList<>();
+            for (int i = 0; i < performanceAWaitedMemberCount; i++) {
+                resultA.add(line.get(performanceAId).poll());
+            }
+            for (int i = 0; i < performanceBWaitedMemberCount; i++) {
+                resultB.add(line.get(performanceBId).poll());
+            }
+            assertThat(resultA).isNotEqualTo(resultB);
+            assertThat(resultA.size()).isEqualTo(performanceAWaitedMemberCount);
+            assertThat(resultB.size()).isEqualTo(performanceBWaitedMemberCount);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManagerTest.java
@@ -1,0 +1,157 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+
+class MemoryWaitingManagerTest {
+
+    private MemoryWaitingManager waitingManager;
+
+    @Nested
+    @DisplayName("웨이팅 룸 입장 메서드 호출 시")
+    class EnterWaitingRoomTest {
+
+        private ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> rawWaitingRoom =
+                new ConcurrentHashMap<>();
+        private ConcurrentMap<Long, AtomicLong> rawWaitingCounter = new ConcurrentHashMap<>();
+        private ConcurrentMap<Long, ConcurrentLinkedQueue<WaitingMember>> rawWaitingLine =
+                new ConcurrentHashMap<>();
+
+        @BeforeEach
+        void setUp() {
+            waitingManager =
+                    new MemoryWaitingManager(
+                            new MemoryWaitingRoom(rawWaitingRoom),
+                            new MemoryWaitingCounter(rawWaitingCounter),
+                            new MemoryWaitingLine(rawWaitingLine));
+        }
+
+        @Test
+        @DisplayName("대기방에 추가한다.")
+        void addMemberToWaitingRoom() {
+            // given
+            long performanceId = 1;
+            String email = "email@email.com";
+
+            // when
+            waitingManager.enterWaitingRoom(email, performanceId);
+
+            // then
+            WaitingMember result = rawWaitingRoom.get(performanceId).get(email);
+            assertThat(result)
+                    .satisfies(
+                            member -> {
+                                assertThat(member).isNotNull();
+                                assertThat(member.getEmail()).isEqualTo(email);
+                                assertThat(member.getPerformanceId()).isEqualTo(performanceId);
+                            });
+        }
+
+        @Test
+        @DisplayName("대기방에 이미 존재하면 대기열에 추가하지 않는다.")
+        void doNotAdd_ifMemberExists() {
+            // given
+            long performanceId = 1;
+            String email = "email@email.com";
+            waitingManager.enterWaitingRoom(email, performanceId);
+
+            // when
+            waitingManager.enterWaitingRoom(email, performanceId);
+
+            // then
+            assertThat(rawWaitingRoom.get(performanceId))
+                    .hasSize(1)
+                    .containsOnlyKeys(email)
+                    .satisfies(
+                            room -> {
+                                WaitingMember member = room.get(email);
+                                assertThat(member)
+                                        .isNotNull()
+                                        .extracting(
+                                                WaitingMember::getEmail,
+                                                WaitingMember::getPerformanceId)
+                                        .containsExactly(email, performanceId);
+                            });
+        }
+
+        @Test
+        @DisplayName("서로 다른 공연은 같은 대기방을 공유하지 않는다.")
+        void doesNotShareRunningRoom_BetweenPerformances() {
+            // given
+            long performanceIdA = 1;
+            long performanceIdB = 2;
+            String email = "email@email.com";
+
+            // when
+            waitingManager.enterWaitingRoom(email, performanceIdA);
+            waitingManager.enterWaitingRoom(email, performanceIdB);
+
+            // then
+            // then
+            assertThat(rawWaitingRoom)
+                    .hasSize(2)
+                    .satisfies(
+                            rooms -> {
+                                assertThat(rooms.get(performanceIdA))
+                                        .hasSize(1)
+                                        .containsOnlyKeys(email);
+                                assertThat(rooms.get(performanceIdB))
+                                        .hasSize(1)
+                                        .containsOnlyKeys(email);
+                            });
+        }
+
+        @Test
+        @DisplayName("같은 사용자가 동시에 입장해도 대기방에는 한 번만 입장한다.")
+        void sameUserManyEnter() throws InterruptedException {
+            // given
+            int poolSize = 10;
+            long performanceId = 1;
+            String email = "email@email.com";
+            CountDownLatch latch = new CountDownLatch(poolSize);
+            ExecutorService executorService = Executors.newFixedThreadPool(poolSize);
+
+            // when
+            for (int i = 0; i < poolSize; i++) {
+                executorService.execute(
+                        () -> {
+                            try {
+                                waitingManager.enterWaitingRoom(email, performanceId);
+                            } finally {
+                                latch.countDown();
+                            }
+                        });
+            }
+            latch.await();
+
+            // then
+            assertThat(rawWaitingRoom)
+                    .hasSize(1)
+                    .satisfies(
+                            rooms -> {
+                                assertThat(rooms.get(performanceId))
+                                        .hasSize(1)
+                                        .containsOnlyKeys(email)
+                                        .satisfies(
+                                                room -> {
+                                                    WaitingMember member = room.get(email);
+                                                    assertThat(member)
+                                                            .isNotNull()
+                                                            .extracting(
+                                                                    WaitingMember::getEmail,
+                                                                    WaitingMember::getPerformanceId)
+                                                            .containsExactly(email, performanceId);
+                                                });
+                            });
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoomTest.java
@@ -1,0 +1,96 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+
+class MemoryWaitingRoomTest {
+
+    private MemoryWaitingRoom waitingRoom;
+
+    @Nested
+    @DisplayName("대기방 입장 메서드 호출 시")
+    class EnterTest {
+
+        private ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> room;
+
+        @BeforeEach
+        void setUp() {
+            room = new ConcurrentHashMap<>();
+            waitingRoom = new MemoryWaitingRoom(room);
+        }
+
+        @Test
+        @DisplayName("사용자가 없으면 대기방에 추가한다.")
+        void enterIfAbsent() {
+            // given
+            long performanceId = 1;
+            String email = "email@email.com";
+
+            // when
+            boolean enter = waitingRoom.enter(email, performanceId);
+
+            // then
+            assertThat(enter).isTrue();
+            assertThat(room.get(performanceId)).hasSize(1).containsKey(email);
+        }
+
+        @Test
+        @DisplayName("사용자가 있으면 대기방에 추가하지 않는다.")
+        void notEnterIfExist() {
+            // given
+            long performanceId = 1;
+            String email = "email@email.com";
+            room.computeIfAbsent(performanceId, k -> new ConcurrentHashMap<>())
+                    .putIfAbsent(email, new WaitingMember(email, performanceId));
+
+            // when
+            boolean enter = waitingRoom.enter(email, performanceId);
+
+            // then
+            assertThat(enter).isFalse();
+            assertThat(room.get(performanceId)).hasSize(1).containsKey(email);
+        }
+    }
+
+    @Nested
+    @DisplayName("대기방 사용자 업데이트 메서드 호출 시")
+    class UpdateMemberInfoTest {
+
+        private ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> room;
+
+        @BeforeEach
+        void setUp() {
+            room = new ConcurrentHashMap<>();
+            waitingRoom = new MemoryWaitingRoom(room);
+        }
+
+        @Test
+        @DisplayName("사용자 정보를 업데이트 한다.")
+        void updateWaitingMemberInfo() {
+            // given
+            String email = "email@email.com";
+            long performanceId = 1;
+            long waitingCount = 1;
+            boolean enter = waitingRoom.enter(email, performanceId);
+            WaitingMember waitingMember =
+                    new WaitingMember(email, performanceId, waitingCount, ZonedDateTime.now());
+
+            // then
+            waitingRoom.updateMemberInfo(waitingMember);
+
+            // then
+            WaitingMember result = room.get(performanceId).get(email);
+            assertThat(result).isEqualTo(waitingMember);
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 사용자를 메모리 대기열에 삽입하고
- 동일한 사용자의 중복 요청을 무시합니다.
- 각 공연마다 다른 대기열을 가집니다.

### 📝 작업 요약
- 사용자를 메모리 대기열에 삽입한다.

### 💡 관련 이슈
- close #69 
