### PR TITLE
Feature: 대기열의 사용자를 레디스의 작업 가능 공간으로 이동시킨다. 

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounter.java
@@ -7,12 +7,16 @@ import com.thirdparty.ticketing.domain.waitingsystem.running.RunningCounter;
 
 public class RedisRunningCounter implements RunningCounter {
 
-    private static final String RUNNING_COUNTER = "running_counter:";
+    private static final String RUNNING_COUNTER_KEY = "running_counter:";
 
     private final ValueOperations<String, String> runningCounter;
 
     public RedisRunningCounter(StringRedisTemplate redisTemplate) {
         this.runningCounter = redisTemplate.opsForValue();
+    }
+
+    public void increment(long performanceId, int number) {
+        runningCounter.increment(getRunningCounterKey(performanceId), number);
     }
 
     public long getRunningCount(long performanceId) {
@@ -23,6 +27,6 @@ public class RedisRunningCounter implements RunningCounter {
     }
 
     private String getRunningCounterKey(long performanceId) {
-        return RUNNING_COUNTER + performanceId;
+        return RUNNING_COUNTER_KEY + performanceId;
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -25,9 +25,13 @@ public class RedisRunningManager implements RunningManager {
 
     @Override
     public long getAvailableToRunning(long performanceId) {
-        return 0;
+        long availableToRunning = runningRoom.getAvailableToRunning(performanceId);
+        return availableToRunning < 0 ? 0 : availableToRunning;
     }
 
     @Override
-    public void enterRunningRoom(long performanceId, Set<WaitingMember> waitingMembers) {}
+    public void enterRunningRoom(long performanceId, Set<WaitingMember> waitingMembers) {
+        runningCounter.increment(performanceId, waitingMembers.size());
+        runningRoom.enter(performanceId, waitingMembers);
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -1,5 +1,7 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import java.util.Set;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -22,6 +24,13 @@ public class RedisRunningRoom implements RunningRoom {
 
     public long getAvailableToRunning(long performanceId) {
         return MAX_RUNNING_ROOM_SIZE - runningRoom.size(getRunningRoomKey(performanceId));
+    }
+
+    public void enter(long performanceId, Set<WaitingMember> waitingMembers) {
+        String[] emails = waitingMembers.stream()
+                .map(WaitingMember::getEmail)
+                .toArray(String[]::new);
+        runningRoom.add(getRunningRoomKey(performanceId), emails);
     }
 
     private String getRunningRoomKey(long performanceId) {

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -27,6 +27,9 @@ public class RedisRunningRoom implements RunningRoom {
     }
 
     public void enter(long performanceId, Set<WaitingMember> waitingMembers) {
+        if (waitingMembers.isEmpty()) {
+            return;
+        }
         String[] emails = waitingMembers.stream()
                 .map(WaitingMember::getEmail)
                 .toArray(String[]::new);

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -7,6 +7,7 @@ import com.thirdparty.ticketing.domain.waitingsystem.running.RunningRoom;
 
 public class RedisRunningRoom implements RunningRoom {
 
+    private static final int MAX_RUNNING_ROOM_SIZE = 100;
     private static final String RUNNING_ROOM_KEY = "running_room:";
 
     private final SetOperations<String, String> runningRoom;
@@ -17,6 +18,10 @@ public class RedisRunningRoom implements RunningRoom {
 
     public boolean contains(String email, long performanceId) {
         return runningRoom.isMember(getRunningRoomKey(performanceId), email);
+    }
+
+    public long getAvailableToRunning(long performanceId) {
+        return MAX_RUNNING_ROOM_SIZE - runningRoom.size(getRunningRoomKey(performanceId));
     }
 
     private String getRunningRoomKey(long performanceId) {

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -1,11 +1,12 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.util.Set;
+
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import com.thirdparty.ticketing.domain.waitingsystem.running.RunningRoom;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
 public class RedisRunningRoom implements RunningRoom {
 
@@ -30,9 +31,8 @@ public class RedisRunningRoom implements RunningRoom {
         if (waitingMembers.isEmpty()) {
             return;
         }
-        String[] emails = waitingMembers.stream()
-                .map(WaitingMember::getEmail)
-                .toArray(String[]::new);
+        String[] emails =
+                waitingMembers.stream().map(WaitingMember::getEmail).toArray(String[]::new);
         runningRoom.add(getRunningRoomKey(performanceId), emails);
     }
 

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLine.java
@@ -3,6 +3,7 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
@@ -36,10 +37,18 @@ public class RedisWaitingLine implements WaitingLine {
     }
 
     public Set<WaitingMember> pullOutMembers(long performanceId, long availableToRunning) {
-        return Optional.ofNullable(waitingLine.popMin(getWaitingLineKey(performanceId), availableToRunning))
-                .map(set -> set.stream()
-                        .map(value -> ObjectMapperUtils.readValue(objectMapper, value.getValue(), WaitingMember.class))
-                        .collect(Collectors.toSet()))
+        return Optional.ofNullable(
+                        waitingLine.popMin(getWaitingLineKey(performanceId), availableToRunning))
+                .map(
+                        set ->
+                                set.stream()
+                                        .map(
+                                                value ->
+                                                        ObjectMapperUtils.readValue(
+                                                                objectMapper,
+                                                                value.getValue(),
+                                                                WaitingMember.class))
+                                        .collect(Collectors.toSet()))
                 .orElseGet(Set::of);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLine.java
@@ -1,5 +1,8 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
@@ -30,5 +33,13 @@ public class RedisWaitingLine implements WaitingLine {
 
     private String getWaitingLineKey(long performanceId) {
         return WAITING_LINE_KEY + performanceId;
+    }
+
+    public Set<WaitingMember> pullOutMembers(long performanceId, long availableToRunning) {
+        return Optional.ofNullable(waitingLine.popMin(getWaitingLineKey(performanceId), availableToRunning))
+                .map(set -> set.stream()
+                        .map(value -> ObjectMapperUtils.readValue(objectMapper, value.getValue(), WaitingMember.class))
+                        .collect(Collectors.toSet()))
+                .orElseGet(Set::of);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
@@ -39,6 +39,6 @@ public class RedisWaitingManager implements WaitingManager {
 
     @Override
     public Set<WaitingMember> pullOutMembers(long performanceId, long availableToRunning) {
-        return Set.of();
+        return waitingLine.pullOutMembers(performanceId, availableToRunning);
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -95,50 +95,41 @@ class WaitingSystemTest extends TestContainerStarter {
         @Test
         @DisplayName("작업 가능 공간의 수용 가능한 인원이 감소한다.")
         void decrementAvailableCount() {
-            //given
+            // given
             long performanceId = 1;
             int memberCount = 25;
-            for(int i = 0; i< memberCount; i++) {
-                waitingManager.enterWaitingRoom(
-                        "email" + i + "@email.com",
-                        performanceId
-                );
+            for (int i = 0; i < memberCount; i++) {
+                waitingManager.enterWaitingRoom("email" + i + "@email.com", performanceId);
             }
 
-            //when
+            // when
             waitingSystem.moveUserToRunning(performanceId);
 
-            //then
+            // then
             assertThat(runningManager.getRunningCount(performanceId)).isEqualTo(memberCount);
-            assertThat(runningManager.getAvailableToRunning(performanceId)).isEqualTo(100 - memberCount);
+            assertThat(runningManager.getAvailableToRunning(performanceId))
+                    .isEqualTo(100 - memberCount);
         }
-
 
         @Test
         @DisplayName("더 이상 인원을 수용할 수 없으면 작업 가능 공간에 사용자를 추가하지 않는다.")
         void doNotMoveUserToRunning_WhenNoMoreAvailableSpace() {
-            //given
+            // given
             long performanceId = 1;
-            for (int i=0; i<100; i++) {
-                waitingSystem.enterWaitingRoom(
-                        "email" + i + "@email.com",
-                        performanceId
-                );
+            for (int i = 0; i < 100; i++) {
+                waitingSystem.enterWaitingRoom("email" + i + "@email.com", performanceId);
             }
             waitingSystem.moveUserToRunning(performanceId);
 
             int memberCount = 25;
-            for(int i = 0; i< memberCount; i++) {
-                waitingManager.enterWaitingRoom(
-                        "email" + i + "@email.com",
-                        performanceId
-                );
+            for (int i = 0; i < memberCount; i++) {
+                waitingManager.enterWaitingRoom("email" + i + "@email.com", performanceId);
             }
 
-            //when
+            // when
             waitingSystem.moveUserToRunning(performanceId);
 
-            //then
+            // then
             assertThat(runningManager.getRunningCount(performanceId)).isEqualTo(100);
             assertThat(runningManager.getAvailableToRunning(performanceId)).isEqualTo(0);
         }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -87,4 +87,60 @@ class WaitingSystemTest extends TestContainerStarter {
             assertThat(eventPublisher.counter).hasValue(1);
         }
     }
+
+    @Nested
+    @DisplayName("대기열 사용자 작업 가능 공간 이동 호출 시")
+    class MoveUserToRunningTest {
+
+        @Test
+        @DisplayName("작업 가능 공간의 수용 가능한 인원이 감소한다.")
+        void decrementAvailableCount() {
+            //given
+            long performanceId = 1;
+            int memberCount = 25;
+            for(int i = 0; i< memberCount; i++) {
+                waitingManager.enterWaitingRoom(
+                        "email" + i + "@email.com",
+                        performanceId
+                );
+            }
+
+            //when
+            waitingSystem.moveUserToRunning(performanceId);
+
+            //then
+            assertThat(runningManager.getRunningCount(performanceId)).isEqualTo(memberCount);
+            assertThat(runningManager.getAvailableToRunning(performanceId)).isEqualTo(100 - memberCount);
+        }
+
+
+        @Test
+        @DisplayName("더 이상 인원을 수용할 수 없으면 작업 가능 공간에 사용자를 추가하지 않는다.")
+        void doNotMoveUserToRunning_WhenNoMoreAvailableSpace() {
+            //given
+            long performanceId = 1;
+            for (int i=0; i<100; i++) {
+                waitingSystem.enterWaitingRoom(
+                        "email" + i + "@email.com",
+                        performanceId
+                );
+            }
+            waitingSystem.moveUserToRunning(performanceId);
+
+            int memberCount = 25;
+            for(int i = 0; i< memberCount; i++) {
+                waitingManager.enterWaitingRoom(
+                        "email" + i + "@email.com",
+                        performanceId
+                );
+            }
+
+            //when
+            waitingSystem.moveUserToRunning(performanceId);
+
+            //then
+            assertThat(runningManager.getRunningCount(performanceId)).isEqualTo(100);
+            assertThat(runningManager.getAvailableToRunning(performanceId)).isEqualTo(0);
+        }
+    }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
@@ -46,7 +46,8 @@ public class TestRedisConfig {
 
     @Bean
     public RedisRunningManager runningManager(
-            RedisRunningRoom runningRoom, RedisRunningCounter runningCounter) {
+            RedisRunningCounter runningCounter,
+            RedisRunningRoom runningRoom) {
         return new RedisRunningManager(runningRoom, runningCounter);
     }
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/TestRedisConfig.java
@@ -46,8 +46,7 @@ public class TestRedisConfig {
 
     @Bean
     public RedisRunningManager runningManager(
-            RedisRunningCounter runningCounter,
-            RedisRunningRoom runningRoom) {
+            RedisRunningCounter runningCounter, RedisRunningRoom runningRoom) {
         return new RedisRunningManager(runningRoom, runningCounter);
     }
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
@@ -91,4 +91,24 @@ class RedisRunningCounterTest extends TestContainerStarter {
             assertThat(runningCount).isEqualTo(10);
         }
     }
+
+    @Nested
+    @DisplayName("카운터 증가 호출 시")
+    class IncrementTest {
+
+        @Test
+        @DisplayName("주어진 값만큼 값을 증가시킨다.")
+        void increment() {
+            //given
+            long performanceId = 1;
+            int number = 10;
+
+            //when
+            runningCounter.increment(performanceId, number);
+
+            //then
+            long runningCount = runningCounter.getRunningCount(performanceId);
+            assertThat(runningCount).isEqualTo(number);
+        }
+    }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
@@ -99,14 +99,14 @@ class RedisRunningCounterTest extends TestContainerStarter {
         @Test
         @DisplayName("주어진 값만큼 값을 증가시킨다.")
         void increment() {
-            //given
+            // given
             long performanceId = 1;
             int number = 10;
 
-            //when
+            // when
             runningCounter.increment(performanceId, number);
 
-            //then
+            // then
             long runningCount = runningCounter.getRunningCount(performanceId);
             assertThat(runningCount).isEqualTo(number);
         }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
@@ -2,6 +2,10 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -9,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -19,20 +24,28 @@ import com.thirdparty.ticketing.support.TestContainerStarter;
 @Import(TestRedisConfig.class)
 class RedisRunningManagerTest extends TestContainerStarter {
 
-    @Autowired private RedisRunningManager runningManager;
+    @Autowired
+    private RedisRunningManager runningManager;
 
-    @Autowired private StringRedisTemplate redisTemplate;
+    @Autowired
+    private StringRedisTemplate redisTemplate;
 
     private ValueOperations<String, String> rawRunningCounter;
+    private SetOperations<String, String> rawRunningRoom;
 
     @BeforeEach
     void setUp() {
         rawRunningCounter = redisTemplate.opsForValue();
+        rawRunningRoom = redisTemplate.opsForSet();
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
     private String getRunningCounterKey(long performanceId) {
         return "running_counter:" + performanceId;
+    }
+
+    private String getRunningRoomKey(long performanceId) {
+        return "running_room:" + performanceId;
     }
 
     @Nested
@@ -64,6 +77,107 @@ class RedisRunningManagerTest extends TestContainerStarter {
 
             // then
             assertThat(runningCount).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 가능 인원 조회 시")
+    class GetAvailableToRunning {
+
+        @Test
+        @DisplayName("0보다 작으면 0을 반환한다.")
+        void returnZero_WhenLessThanZero() {
+            //given
+            long performanceId = 1;
+            Set<WaitingMember> waitingMembers = new HashSet<>();
+            for (int i = 0; i < 150; i++) {
+                waitingMembers.add(new WaitingMember(
+                        "email" + i + "@email.com",
+                        performanceId,
+                        i,
+                        ZonedDateTime.now()
+                ));
+            }
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            //when
+            long availableToRunning = runningManager.getAvailableToRunning(performanceId);
+
+            //then
+            assertThat(availableToRunning).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("0보다 크면 그대로 반환한다.")
+        void returnAvailable_WhenGreaterThanZero() {
+            //given
+            long performanceId = 1;
+            Set<WaitingMember> waitingMembers = new HashSet<>();
+            for (int i = 0; i < 20; i++) {
+                waitingMembers.add(new WaitingMember(
+                        "email" + i + "@email.com",
+                        performanceId,
+                        i,
+                        ZonedDateTime.now()
+                ));
+            }
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            //when
+            long runningCount = runningManager.getAvailableToRunning(performanceId);
+
+            //then
+            assertThat(runningCount).isEqualTo(80);
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 가능 공간 입장 호출 시")
+    class EnterRunningRoomTest {
+
+        private Set<WaitingMember> waitingMembers;
+        private int waitingMemberCount;
+        private long performanceId;
+
+        @BeforeEach
+        void setUp() {
+            waitingMemberCount = 20;
+            performanceId = 1;
+            waitingMembers = new HashSet<>();
+            for (int i = 0; i < waitingMemberCount; i++) {
+                waitingMembers.add(new WaitingMember(
+                        "email" + i + "@email.com",
+                        performanceId,
+                        i,
+                        ZonedDateTime.now()
+                ));
+            }
+        }
+
+        @Test
+        @DisplayName("입장 인원만큼 작업 가능 공간 이동 인원 카운터를 증가시킨다.")
+        void incrementRunningCounter() {
+            //given
+
+            //when
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            //then
+            long runningCount = runningManager.getRunningCount(performanceId);
+            assertThat(runningCount).isEqualTo(waitingMemberCount);
+        }
+
+        @Test
+        @DisplayName("작업 가능 공간에 사용자를 추가한다.")
+        void enterRunningRoom() {
+            //given
+
+            //when
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            //then
+            Set<String> waitingMembers = rawRunningRoom.members(getRunningRoomKey(performanceId));
+            assertThat(waitingMembers).hasSize(waitingMemberCount);
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
@@ -2,10 +2,10 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +17,7 @@ import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
@@ -24,11 +25,9 @@ import com.thirdparty.ticketing.support.TestContainerStarter;
 @Import(TestRedisConfig.class)
 class RedisRunningManagerTest extends TestContainerStarter {
 
-    @Autowired
-    private RedisRunningManager runningManager;
+    @Autowired private RedisRunningManager runningManager;
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+    @Autowired private StringRedisTemplate redisTemplate;
 
     private ValueOperations<String, String> rawRunningCounter;
     private SetOperations<String, String> rawRunningRoom;
@@ -87,46 +86,40 @@ class RedisRunningManagerTest extends TestContainerStarter {
         @Test
         @DisplayName("0보다 작으면 0을 반환한다.")
         void returnZero_WhenLessThanZero() {
-            //given
+            // given
             long performanceId = 1;
             Set<WaitingMember> waitingMembers = new HashSet<>();
             for (int i = 0; i < 150; i++) {
-                waitingMembers.add(new WaitingMember(
-                        "email" + i + "@email.com",
-                        performanceId,
-                        i,
-                        ZonedDateTime.now()
-                ));
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
             }
             runningManager.enterRunningRoom(performanceId, waitingMembers);
 
-            //when
+            // when
             long availableToRunning = runningManager.getAvailableToRunning(performanceId);
 
-            //then
+            // then
             assertThat(availableToRunning).isEqualTo(0);
         }
 
         @Test
         @DisplayName("0보다 크면 그대로 반환한다.")
         void returnAvailable_WhenGreaterThanZero() {
-            //given
+            // given
             long performanceId = 1;
             Set<WaitingMember> waitingMembers = new HashSet<>();
             for (int i = 0; i < 20; i++) {
-                waitingMembers.add(new WaitingMember(
-                        "email" + i + "@email.com",
-                        performanceId,
-                        i,
-                        ZonedDateTime.now()
-                ));
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
             }
             runningManager.enterRunningRoom(performanceId, waitingMembers);
 
-            //when
+            // when
             long runningCount = runningManager.getAvailableToRunning(performanceId);
 
-            //then
+            // then
             assertThat(runningCount).isEqualTo(80);
         }
     }
@@ -145,24 +138,21 @@ class RedisRunningManagerTest extends TestContainerStarter {
             performanceId = 1;
             waitingMembers = new HashSet<>();
             for (int i = 0; i < waitingMemberCount; i++) {
-                waitingMembers.add(new WaitingMember(
-                        "email" + i + "@email.com",
-                        performanceId,
-                        i,
-                        ZonedDateTime.now()
-                ));
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
             }
         }
 
         @Test
         @DisplayName("입장 인원만큼 작업 가능 공간 이동 인원 카운터를 증가시킨다.")
         void incrementRunningCounter() {
-            //given
+            // given
 
-            //when
+            // when
             runningManager.enterRunningRoom(performanceId, waitingMembers);
 
-            //then
+            // then
             long runningCount = runningManager.getRunningCount(performanceId);
             assertThat(runningCount).isEqualTo(waitingMemberCount);
         }
@@ -170,12 +160,12 @@ class RedisRunningManagerTest extends TestContainerStarter {
         @Test
         @DisplayName("작업 가능 공간에 사용자를 추가한다.")
         void enterRunningRoom() {
-            //given
+            // given
 
-            //when
+            // when
             runningManager.enterRunningRoom(performanceId, waitingMembers);
 
-            //then
+            // then
             Set<String> waitingMembers = rawRunningRoom.members(getRunningRoomKey(performanceId));
             assertThat(waitingMembers).hasSize(waitingMemberCount);
         }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -2,12 +2,10 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,6 +17,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 @Import(TestRedisConfig.class)
@@ -95,23 +97,19 @@ class RedisRunningRoomTest extends TestContainerStarter {
     class GetAvailableToRunningTest {
 
         @ParameterizedTest
-        @CsvSource({
-                "0, 100",
-                "50, 50",
-                "100, 0"
-        })
+        @CsvSource({"0, 100", "50, 50", "100, 0"})
         @DisplayName("남아있는 자리를 반환한다.")
         void getAvailableToRunning(int runningMembers, int expectedAvailableToRunning) {
-            //given
+            // given
             long performanceId = 1;
-            for(int i=0; i<runningMembers; i++) {
+            for (int i = 0; i < runningMembers; i++) {
                 rawRunningRoom.add(getRunningRoomKey(performanceId), "email" + i + "@email.com");
             }
 
-            //when
+            // when
             long availableToRunning = runningRoom.getAvailableToRunning(performanceId);
 
-            //then
+            // then
             assertThat(availableToRunning).isEqualTo(expectedAvailableToRunning);
         }
     }
@@ -123,25 +121,21 @@ class RedisRunningRoomTest extends TestContainerStarter {
         @Test
         @DisplayName("사용자의 이메일 정보를 작업 가능 공간에 넣는다.")
         void putEmailInfo() {
-            //given
+            // given
             long performanceId = 1;
             Set<WaitingMember> waitingMembers = new HashSet<>();
-            for(int i=0; i<10; i++) {
-                waitingMembers.add(new WaitingMember(
-                        "email" + i + "@email.com",
-                        performanceId,
-                        i,
-                        ZonedDateTime.now()
-                ));
+            for (int i = 0; i < 10; i++) {
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
             }
 
-            //when
+            // when
             runningRoom.enter(performanceId, waitingMembers);
 
-            //then
-            String[] emails = waitingMembers.stream()
-                    .map(WaitingMember::getEmail)
-                    .toArray(String[]::new);
+            // then
+            String[] emails =
+                    waitingMembers.stream().map(WaitingMember::getEmail).toArray(String[]::new);
             assertThat(rawRunningRoom.isMember(getRunningRoomKey(performanceId), emails))
                     .allSatisfy((key, value) -> assertThat(value).isTrue());
         }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -2,18 +2,19 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
-
-import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 @Import(TestRedisConfig.class)
@@ -23,8 +24,11 @@ class RedisRunningRoomTest extends TestContainerStarter {
 
     @Autowired private StringRedisTemplate redisTemplate;
 
+    private SetOperations<String, String> rawRunningRoom;
+
     @BeforeEach
     void setUp() {
+        rawRunningRoom = redisTemplate.opsForSet();
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
@@ -35,13 +39,6 @@ class RedisRunningRoomTest extends TestContainerStarter {
     @Nested
     @DisplayName("러닝룸에 사용자가 있는지 확인했을 때")
     class ContainsTest {
-
-        private SetOperations<String, String> rawRunningRoom;
-
-        @BeforeEach
-        void setUp() {
-            rawRunningRoom = redisTemplate.opsForSet();
-        }
 
         @Test
         @DisplayName("사용자가 포함되어 있다면 true를 반환한다.")
@@ -86,6 +83,32 @@ class RedisRunningRoomTest extends TestContainerStarter {
 
             // then
             assertThat(contains).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 가능 공간에 빈 자리가 있는지 조회 시")
+    class GetAvailableToRunningTest {
+
+        @ParameterizedTest
+        @CsvSource({
+                "0, 100",
+                "50, 50",
+                "100, 0"
+        })
+        @DisplayName("남아있는 자리를 반환한다.")
+        void getAvailableToRunning(int runningMembers, int expectedAvailableToRunning) {
+            //given
+            long performanceId = 1;
+            for(int i=0; i<runningMembers; i++) {
+                rawRunningRoom.add(getRunningRoomKey(performanceId), "email" + i + "@email.com");
+            }
+
+            //when
+            long availableToRunning = runningRoom.getAvailableToRunning(performanceId);
+
+            //then
+            assertThat(availableToRunning).isEqualTo(expectedAvailableToRunning);
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -2,8 +2,12 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
 import com.thirdparty.ticketing.support.TestContainerStarter;
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -109,6 +113,37 @@ class RedisRunningRoomTest extends TestContainerStarter {
 
             //then
             assertThat(availableToRunning).isEqualTo(expectedAvailableToRunning);
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 가능 공간 입장 호출 시")
+    class EnterTest {
+
+        @Test
+        @DisplayName("사용자의 이메일 정보를 작업 가능 공간에 넣는다.")
+        void putEmailInfo() {
+            //given
+            long performanceId = 1;
+            Set<WaitingMember> waitingMembers = new HashSet<>();
+            for(int i=0; i<10; i++) {
+                waitingMembers.add(new WaitingMember(
+                        "email" + i + "@email.com",
+                        performanceId,
+                        i,
+                        ZonedDateTime.now()
+                ));
+            }
+
+            //when
+            runningRoom.enter(performanceId, waitingMembers);
+
+            //then
+            String[] emails = waitingMembers.stream()
+                    .map(WaitingMember::getEmail)
+                    .toArray(String[]::new);
+            assertThat(rawRunningRoom.isMember(getRunningRoomKey(performanceId), emails))
+                    .allSatisfy((key, value) -> assertThat(value).isTrue());
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
@@ -155,23 +155,20 @@ class RedisWaitingLineTest extends TestContainerStarter {
         @Test
         @DisplayName("대기 번호가 낮은 순으로 꺼내온다.")
         void pullOutMembers_LowestWaitingCount() {
-            //given
+            // given
             long performanceId = 1;
             int memberCount = 20;
-            for(int i=1; i <= memberCount; i++) {
-                WaitingMember waitingMember = new WaitingMember(
-                        "email" + i + "@email.com",
-                        performanceId,
-                        i,
-                        ZonedDateTime.now()
-                );
+            for (int i = 1; i <= memberCount; i++) {
+                WaitingMember waitingMember =
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now());
                 waitingLine.enter(waitingMember);
             }
 
-            //when
+            // when
             Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, 5);
 
-            //then
+            // then
             assertThat(waitingMembers)
                     .map(WaitingMember::getWaitingCount)
                     .containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L);
@@ -180,23 +177,21 @@ class RedisWaitingLineTest extends TestContainerStarter {
         @Test
         @DisplayName("꺼내올 인원이 대기열의 인원보다 많은 경우 모든 인원을 꺼내온다.")
         void whenAvailableToRunningIsGraterThanRunningLineSize() {
-            //given
+            // given
             long performanceId = 1;
             int memberCount = 5;
-            for(int i=1; i <= memberCount; i++) {
-                WaitingMember waitingMember = new WaitingMember(
-                        "email" + i + "@email.com",
-                        performanceId,
-                        i,
-                        ZonedDateTime.now()
-                );
+            for (int i = 1; i <= memberCount; i++) {
+                WaitingMember waitingMember =
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now());
                 waitingLine.enter(waitingMember);
             }
 
-            //when
-            Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, memberCount + 20);
+            // when
+            Set<WaitingMember> waitingMembers =
+                    waitingLine.pullOutMembers(performanceId, memberCount + 20);
 
-            //then
+            // then
             assertThat(waitingMembers)
                     .map(WaitingMember::getWaitingCount)
                     .containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L);
@@ -205,13 +200,13 @@ class RedisWaitingLineTest extends TestContainerStarter {
         @Test
         @DisplayName("대기열에서 꺼낼 인원이 없으면 빈 set을 반환한다.")
         void whenEmpty() {
-            //given
+            // given
             long performanceId = 1;
 
-            //when
+            // when
             Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, 20);
 
-            //then
+            // then
             assertThat(waitingMembers).isEmpty();
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
@@ -147,4 +147,72 @@ class RedisWaitingLineTest extends TestContainerStarter {
             assertThat(performanceBWaitedMembers).hasSize(performanceBWaitedMemberCount);
         }
     }
+
+    @Nested
+    @DisplayName("대기열에서 사용자를 꺼내올 떄")
+    class PullOutMembersTest {
+
+        @Test
+        @DisplayName("대기 번호가 낮은 순으로 꺼내온다.")
+        void pullOutMembers_LowestWaitingCount() {
+            //given
+            long performanceId = 1;
+            int memberCount = 20;
+            for(int i=1; i <= memberCount; i++) {
+                WaitingMember waitingMember = new WaitingMember(
+                        "email" + i + "@email.com",
+                        performanceId,
+                        i,
+                        ZonedDateTime.now()
+                );
+                waitingLine.enter(waitingMember);
+            }
+
+            //when
+            Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, 5);
+
+            //then
+            assertThat(waitingMembers)
+                    .map(WaitingMember::getWaitingCount)
+                    .containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L);
+        }
+
+        @Test
+        @DisplayName("꺼내올 인원이 대기열의 인원보다 많은 경우 모든 인원을 꺼내온다.")
+        void whenAvailableToRunningIsGraterThanRunningLineSize() {
+            //given
+            long performanceId = 1;
+            int memberCount = 5;
+            for(int i=1; i <= memberCount; i++) {
+                WaitingMember waitingMember = new WaitingMember(
+                        "email" + i + "@email.com",
+                        performanceId,
+                        i,
+                        ZonedDateTime.now()
+                );
+                waitingLine.enter(waitingMember);
+            }
+
+            //when
+            Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, memberCount + 20);
+
+            //then
+            assertThat(waitingMembers)
+                    .map(WaitingMember::getWaitingCount)
+                    .containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L);
+        }
+
+        @Test
+        @DisplayName("대기열에서 꺼낼 인원이 없으면 빈 set을 반환한다.")
+        void whenEmpty() {
+            //given
+            long performanceId = 1;
+
+            //when
+            Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, 20);
+
+            //then
+            assertThat(waitingMembers).isEmpty();
+        }
+    }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 대기열 사용자 추출 후 작업 가능 공간으로 이동시키는 기능을 구현하였습니다.
  - 작업 가능 공간 `RunningRoom`에서 사용자 몇명을 수용할 수 있는지 확인합니다.
    - 현재 작업 가능 공간에서 수용할 수 있는 최대 인원은 100명으로 설정하였습니다.
  - 수용 가능한 인원 수 `availableCount`만큼 대기열 `WaitingLine`에서 대기중인 사용자를 `waitingCount`가 낮은 순으로 추출합니다.
  - 대기열에서 추출한 사용자 목록 `waitingMembers`의 사이즈만큼 작업 가능 공간으로 이동한 인원을 측정하는 `RunningCount`의 값을 증가시킵니다.
  - 작업 가능 공간 `RunningRoom`에 사용자를 입장시킵니다.

- 해당 기능은 폴링 이벤트로 트리거할 예정입니다. 또한, 동시에 하나의 스레드만 해당 기능을 실행시킬 수 있도록 별도의 락을 적용할 예정입니다.

### 📝 작업 요약
- 대기열 사용자 추출 -> 작업 가능 공간 추가 기능 구현

### 💡 관련 이슈
- close #74 
