### PR TITLE
Feature: 사용자의 남은 대기 순번을 메모리에서 조회한다.

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningCounter.java
@@ -1,0 +1,17 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.running;
+
+import java.util.concurrent.ConcurrentMap;
+
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningCounter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemoryRunningCounter implements RunningCounter {
+
+    private final ConcurrentMap<Long, Long> counter;
+
+    public long getRunningCounter(long performanceId) {
+        return counter.getOrDefault(performanceId, 0L);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 public class MemoryRunningManager implements RunningManager {
 
     private final MemoryRunningRoom runningRoom;
+    private final MemoryRunningCounter runningCounter;
 
     @Override
     public boolean isReadyToHandle(String email, long performanceId) {
@@ -19,7 +20,7 @@ public class MemoryRunningManager implements RunningManager {
 
     @Override
     public long getRunningCount(long performanceId) {
-        return 0;
+        return runningCounter.getRunningCounter(performanceId);
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
@@ -3,6 +3,8 @@ package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
@@ -28,7 +30,9 @@ public class MemoryWaitingManager implements WaitingManager {
 
     @Override
     public WaitingMember findWaitingMember(String email, long performanceId) {
-        return null;
+        return waitingRoom
+                .findWaitingMember(email, performanceId)
+                .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_WAITING_MEMBER));
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
@@ -1,5 +1,6 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -22,5 +23,9 @@ public class MemoryWaitingRoom implements WaitingRoom {
     public void updateMemberInfo(WaitingMember waitingMember) {
         room.computeIfAbsent(waitingMember.getPerformanceId(), k -> new ConcurrentHashMap<>())
                 .put(waitingMember.getEmail(), waitingMember);
+    }
+
+    public Optional<WaitingMember> findWaitingMember(String email, long performanceId) {
+        return Optional.ofNullable(room.get(performanceId)).map(map -> map.get(email));
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManagerTest.java
@@ -1,0 +1,61 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.running;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+
+class MemoryRunningManagerTest {
+
+    private MemoryRunningManager runningManager;
+    private ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> room;
+    private ConcurrentMap<Long, Long> counter;
+
+    @BeforeEach
+    void setUp() {
+        room = new ConcurrentHashMap<>();
+        counter = new ConcurrentHashMap<>();
+        MemoryRunningRoom runningRoom = new MemoryRunningRoom(room);
+        MemoryRunningCounter runningCounter = new MemoryRunningCounter(counter);
+        runningManager = new MemoryRunningManager(runningRoom, runningCounter);
+    }
+
+    @Nested
+    @DisplayName("러닝 카운트 조회 시")
+    class GetRunningCounterTest {
+
+        @Test
+        @DisplayName("작업 가능 공간으로 진입한 인원 수를 반환한다.")
+        void getRunningCounter() {
+            // given
+            long performanceId = 1;
+            counter.put(performanceId, 44L);
+
+            // when
+            long runningCount = runningManager.getRunningCount(performanceId);
+
+            // then
+            assertThat(runningCount).isEqualTo(44L);
+        }
+
+        @Test
+        @DisplayName("카운트가 존재하지 않으면 0부터 시작한다.")
+        void startCounterWithZeroValue() {
+            // given
+            long performanceId = 1;
+
+            // when
+            long runningCount = runningManager.getRunningCount(performanceId);
+
+            // then
+            assertThat(runningCount).isEqualTo(0L);
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
대기열 시스템의 사용자 남은 순번 조회 기능을 구현했습니다.
WaitingRoom으로 부터 대기중인 사용자 정보를 조회합니다.
RunningCounter로부터 대기열에서 작업 가능 공간으로 이동한 인원수(runningCount)를 조회합니다.
대기중인 사용자 정보 WaitingMember에서 고유 대기 번호 waitingCount 필드에서 runningCount를 뺀 값을 사용자에게 반환합니다.

### 📝 작업 요약
대기열 시스템 사용자 남은 순번 조회 기능 구현

### 💡 관련 이슈
- close #71 
