### PR TITLE
Feature: 대기열의 사용자를 메모리의 작업 가능 공간으로 이동시킨다.

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningCounter.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningCounter.java
@@ -14,4 +14,8 @@ public class MemoryRunningCounter implements RunningCounter {
     public long getRunningCounter(long performanceId) {
         return counter.getOrDefault(performanceId, 0L);
     }
+
+    public void increment(long performanceId, int size) {
+        counter.compute(performanceId, (key, value) -> (value == null) ? size : value + size);
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -29,5 +29,8 @@ public class MemoryRunningManager implements RunningManager {
     }
 
     @Override
-    public void enterRunningRoom(long performanceId, Set<WaitingMember> waitingMembers) {}
+    public void enterRunningRoom(long performanceId, Set<WaitingMember> waitingMembers) {
+        runningCounter.increment(performanceId, waitingMembers.size());
+        runningRoom.enter(performanceId, waitingMembers);
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -25,7 +25,7 @@ public class MemoryRunningManager implements RunningManager {
 
     @Override
     public long getAvailableToRunning(long performanceId) {
-        return 0;
+        return runningRoom.getAvailableToRunning(performanceId);
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemoryRunningRoom implements RunningRoom {
 
+    private static final int MAX_MEMORY_RUNNING_ROOM_SIZE = 100;
+
     private final ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> map;
 
     public boolean contains(String email, long performanceId) {
@@ -17,5 +19,10 @@ public class MemoryRunningRoom implements RunningRoom {
             return false;
         }
         return map.get(performanceId).containsKey(email);
+    }
+
+    public long getAvailableToRunning(long performanceId) {
+        return MAX_MEMORY_RUNNING_ROOM_SIZE
+                - (map.containsKey(performanceId) ? map.get(performanceId).size() : 0);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
@@ -1,5 +1,7 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.running;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import com.thirdparty.ticketing.domain.waitingsystem.running.RunningRoom;
@@ -12,17 +14,30 @@ public class MemoryRunningRoom implements RunningRoom {
 
     private static final int MAX_MEMORY_RUNNING_ROOM_SIZE = 100;
 
-    private final ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> map;
+    private final ConcurrentMap<Long, ConcurrentMap<String, WaitingMember>> room;
 
     public boolean contains(String email, long performanceId) {
-        if (!map.containsKey(performanceId)) {
+        if (!room.containsKey(performanceId)) {
             return false;
         }
-        return map.get(performanceId).containsKey(email);
+        return room.get(performanceId).containsKey(email);
     }
 
     public long getAvailableToRunning(long performanceId) {
-        return MAX_MEMORY_RUNNING_ROOM_SIZE
-                - (map.containsKey(performanceId) ? map.get(performanceId).size() : 0);
+        return Math.max(
+                0,
+                MAX_MEMORY_RUNNING_ROOM_SIZE
+                        - (room.containsKey(performanceId) ? room.get(performanceId).size() : 0));
+    }
+
+    public void enter(long performanceId, Set<WaitingMember> waitingMembers) {
+        room.compute(
+                performanceId,
+                (key, room) -> {
+                    ConcurrentMap<String, WaitingMember> runningRoom =
+                            (room != null) ? room : new ConcurrentHashMap<>();
+                    waitingMembers.forEach(member -> runningRoom.put(member.getEmail(), member));
+                    return runningRoom;
+                });
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLine.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLine.java
@@ -1,7 +1,10 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingLine;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
@@ -16,5 +19,16 @@ public class MemoryWaitingLine implements WaitingLine {
     public void enter(WaitingMember waitingMember) {
         line.computeIfAbsent(waitingMember.getPerformanceId(), k -> new ConcurrentLinkedQueue<>())
                 .offer(waitingMember);
+    }
+
+    public Set<WaitingMember> pullOutMembers(long performanceId, long availableToRunning) {
+        return Optional.ofNullable(line.get(performanceId))
+                .map(
+                        queue ->
+                                Stream.generate(queue::poll)
+                                        .limit(availableToRunning)
+                                        .filter(Objects::nonNull)
+                                        .collect(Collectors.toSet()))
+                .orElseGet(HashSet::new);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
@@ -37,6 +37,6 @@ public class MemoryWaitingManager implements WaitingManager {
 
     @Override
     public Set<WaitingMember> pullOutMembers(long performanceId, long availableToRunning) {
-        return Set.of();
+        return waitingLine.pullOutMembers(performanceId, availableToRunning);
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningCounterTest.java
@@ -1,0 +1,40 @@
+package com.thirdparty.ticketing.global.waitingsystem.memory.running;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MemoryRunningCounterTest {
+
+    private MemoryRunningCounter runningCounter;
+
+    @BeforeEach
+    void setUp() {
+        runningCounter = new MemoryRunningCounter(new ConcurrentHashMap<>());
+    }
+
+    @Nested
+    @DisplayName("카운터 증가 호출 시")
+    class IncrementTest {
+
+        @Test
+        @DisplayName("주어진 값만큼 값을 증가시킨다.")
+        void increment() {
+            // given
+            long performanceId = 1;
+            int number = 10;
+
+            // when
+            runningCounter.increment(performanceId, number);
+
+            // then
+            long runningCount = runningCounter.getRunningCounter(performanceId);
+            assertThat(runningCount).isEqualTo(number);
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManagerTest.java
@@ -2,6 +2,9 @@ package com.thirdparty.ticketing.global.waitingsystem.memory.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -56,6 +59,98 @@ class MemoryRunningManagerTest {
 
             // then
             assertThat(runningCount).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 가능 인원 조회 시")
+    class GetAvailableToRunning {
+
+        @Test
+        @DisplayName("0보다 작으면 0을 반환한다.")
+        void returnZero_WhenLessThanZero() {
+            // given
+            long performanceId = 1;
+            Set<WaitingMember> waitingMembers = new HashSet<>();
+            for (int i = 0; i < 150; i++) {
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
+            }
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            // when
+            long availableToRunning = runningManager.getAvailableToRunning(performanceId);
+
+            // then
+            assertThat(availableToRunning).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("0보다 크면 그대로 반환한다.")
+        void returnAvailable_WhenGreaterThanZero() {
+            // given
+            long performanceId = 1;
+            Set<WaitingMember> waitingMembers = new HashSet<>();
+            for (int i = 0; i < 20; i++) {
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
+            }
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            // when
+            long runningCount = runningManager.getAvailableToRunning(performanceId);
+
+            // then
+            assertThat(runningCount).isEqualTo(80);
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 가능 공간 입장 호출 시")
+    class EnterRunningRoomTest {
+
+        private Set<WaitingMember> waitingMembers;
+        private int waitingMemberCount;
+        private long performanceId;
+
+        @BeforeEach
+        void setUp() {
+            waitingMemberCount = 20;
+            performanceId = 1;
+            waitingMembers = new HashSet<>();
+            for (int i = 0; i < waitingMemberCount; i++) {
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
+            }
+        }
+
+        @Test
+        @DisplayName("입장 인원만큼 작업 가능 공간 이동 인원 카운터를 증가시킨다.")
+        void incrementRunningCounter() {
+            // given
+
+            // when
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            // then
+            long runningCount = runningManager.getRunningCount(performanceId);
+            assertThat(runningCount).isEqualTo(waitingMemberCount);
+        }
+
+        @Test
+        @DisplayName("작업 가능 공간에 사용자를 추가한다.")
+        void enterRunningRoom() {
+            // given
+
+            // when
+            runningManager.enterRunningRoom(performanceId, waitingMembers);
+
+            // then
+            Set<String> waitingMembers = room.get(performanceId).keySet();
+            assertThat(waitingMembers).hasSize(waitingMemberCount);
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
@@ -2,6 +2,9 @@ package com.thirdparty.ticketing.global.waitingsystem.memory.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -98,6 +101,37 @@ class MemoryRunningRoomTest {
 
             // then
             assertThat(availableToRunning).isEqualTo(expectAvailableToRunning);
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 가능 공간 입장 호출 시")
+    class EnterTest {
+
+        @Test
+        @DisplayName("사용자의 이메일 정보를 작업 가능 공간에 넣는다.")
+        void putEmailInfo() {
+            // given
+            long performanceId = 1;
+            Set<WaitingMember> waitingMembers = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                waitingMembers.add(
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now()));
+            }
+
+            // when
+            runningRoom.enter(performanceId, waitingMembers);
+
+            // then
+            String[] emails =
+                    waitingMembers.stream().map(WaitingMember::getEmail).toArray(String[]::new);
+            // 각 이메일이 runningRoom 에 존재하는지 확인
+            for (String email : emails) {
+                assertThat(runningRoom.contains(email, performanceId)).isTrue();
+            }
+            // 존재하지 않는 이메일은 false 를 반환하는지 확인
+            assertThat(runningRoom.contains("nonexistent@email.com", performanceId)).isFalse();
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLineTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingLineTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -20,18 +21,17 @@ import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 class MemoryWaitingLineTest {
 
     private MemoryWaitingLine waitingLine;
+    private ConcurrentMap<Long, ConcurrentLinkedQueue<WaitingMember>> line;
+
+    @BeforeEach
+    void setUp() {
+        line = new ConcurrentHashMap<>();
+        waitingLine = new MemoryWaitingLine(line);
+    }
 
     @Nested
     @DisplayName("대기열 입장 시")
     class EnterTest {
-
-        private ConcurrentMap<Long, ConcurrentLinkedQueue<WaitingMember>> line;
-
-        @BeforeEach
-        void setUp() {
-            line = new ConcurrentHashMap<>();
-            waitingLine = new MemoryWaitingLine(line);
-        }
 
         @Test
         @DisplayName("사용자를 대기열에 추가한다.")
@@ -113,6 +113,69 @@ class MemoryWaitingLineTest {
             assertThat(resultA).isNotEqualTo(resultB);
             assertThat(resultA.size()).isEqualTo(performanceAWaitedMemberCount);
             assertThat(resultB.size()).isEqualTo(performanceBWaitedMemberCount);
+        }
+    }
+
+    @Nested
+    @DisplayName("대기열에서 사용자를 꺼내올 때")
+    class PullOutMembersTest {
+
+        @Test
+        @DisplayName("대기 번호가 낮은 순으로 꺼내온다.")
+        void pullOutMembers_LowestWaitingCounter() {
+            // given
+            long performanceId = 1;
+            int memberCount = 20;
+            for (int i = 1; i <= memberCount; i++) {
+                WaitingMember waitingMember =
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now());
+                waitingLine.enter(waitingMember);
+            }
+
+            // when
+            Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, 5);
+
+            // then
+            assertThat(waitingMembers)
+                    .map(WaitingMember::getWaitingCount)
+                    .containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L);
+        }
+
+        @Test
+        @DisplayName("꺼내올 인원이 대기열의 인원보다 많은 경우 모든 인원을 꺼내온다.")
+        void whenAvailableToRunningIsGraterThanRunningLineSize() {
+            // given
+            long performanceId = 1;
+            int memberCount = 5;
+            for (int i = 1; i <= memberCount; i++) {
+                WaitingMember waitingMember =
+                        new WaitingMember(
+                                "email" + i + "@email.com", performanceId, i, ZonedDateTime.now());
+                waitingLine.enter(waitingMember);
+            }
+
+            // when
+            Set<WaitingMember> waitingMembers =
+                    waitingLine.pullOutMembers(performanceId, memberCount + 20);
+
+            // then
+            assertThat(waitingMembers)
+                    .map(WaitingMember::getWaitingCount)
+                    .containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L);
+        }
+
+        @Test
+        @DisplayName("대기열에서 꺼낼 인원이 없으면 빈 set을 반환한다.")
+        void whenEmpty() {
+            // given
+            long performanceId = 1;
+
+            // when
+            Set<WaitingMember> waitingMembers = waitingLine.pullOutMembers(performanceId, 20);
+
+            // then
+            assertThat(waitingMembers).isEmpty();
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 대기열 사용자 추출 후 작업 가능 공간으로 이동시키는 기능을 구현하였습니다.
- 작업 가능 공간 RunningRoom에서 사용자 몇명을 수용할 수 있는지 확인합니다.
- 현재 작업 가능 공간에서 수용할 수 있는 최대 인원은 100명으로 설정하였습니다.
- 대기열에서 추출한 사용자 목록 waitingMembers의 사이즈만큼 작업 가능 공간으로 이동한 인원을 측정하는 RunningCount의 값을 증가시킵니다.
- 작업 가능 공간 RunningRoom에 사용자를 입장시킵니다.

### 📝 작업 요약
- 메모리의 작업 공간으로 사용자를 이동

### 💡 관련 이슈
- close #73 
