### PR TITLE
Feature: 사용자가 티켓팅 API를 호출하면 대기열 시스템이 동작한다. 

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/common/ErrorCode.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/common/ErrorCode.java
@@ -59,7 +59,8 @@ public enum ErrorCode {
     */
     WAITING_WRITE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "W500-1", "대기열 쓰기에 실패했습니다."),
     WAITING_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "W500-2", "대기열 읽기에 실패했습니다."),
-    NOT_FOUND_WAITING_MEMBER(HttpStatus.NOT_FOUND, "W404-1", "대기열에 회원이 존재하지 않습니다.");
+    NOT_FOUND_WAITING_MEMBER(HttpStatus.NOT_FOUND, "W404-1", "대기열에 회원이 존재하지 않습니다."),
+    NOT_CONTAINS_PERFORMANCE_INFO(HttpStatus.BAD_REQUEST, "W400-1", "공연 정보가 포함되어 있지 않습니다");
 
     ErrorCode(HttpStatus httpStatus, String code, String message) {
         this.httpStatus = httpStatus;

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/Waiting.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/Waiting.java
@@ -7,5 +7,4 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Waiting {
-}
+public @interface Waiting {}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/Waiting.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/Waiting.java
@@ -1,0 +1,11 @@
+package com.thirdparty.ticketing.domain.waitingsystem;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Waiting {
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspect.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspect.java
@@ -1,12 +1,10 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
-import com.thirdparty.ticketing.domain.common.ErrorCode;
-import com.thirdparty.ticketing.domain.common.TicketingException;
-import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -16,6 +14,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Aspect
@@ -29,9 +33,13 @@ public class WaitingAspect {
         HttpServletRequest request =
                 ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
                         .getRequest();
-        long performanceId = Optional.ofNullable(request.getHeader("performanceId"))
-                .map(Long::parseLong)
-                .orElseThrow(() -> new TicketingException(ErrorCode.NOT_CONTAINS_PERFORMANCE_INFO));
+        long performanceId =
+                Optional.ofNullable(request.getHeader("performanceId"))
+                        .map(Long::parseLong)
+                        .orElseThrow(
+                                () ->
+                                        new TicketingException(
+                                                ErrorCode.NOT_CONTAINS_PERFORMANCE_INFO));
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = (String) authentication.getPrincipal();

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
@@ -6,11 +6,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.thirdparty.ticketing.domain.common.LoginMember;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.thirdparty.ticketing.domain.common.LoginMember;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class WaitingController {
@@ -18,7 +20,7 @@ public class WaitingController {
     private final WaitingSystem waitingSystem;
 
     @GetMapping("/performances/{performanceId}/wait")
-    public ResponseEntity<Map<String, Long>> getCounts(
+    public ResponseEntity<Map<String, Long>> getRemainingCount(
             @LoginMember String email, @PathVariable("performanceId") Long performanceId) {
         long remainingCount = waitingSystem.getRemainingCount(email, performanceId);
         return ResponseEntity.ok(Map.of("remainingCount", remainingCount));

--- a/src/main/java/com/thirdparty/ticketing/global/config/WaitingConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/WaitingConfig.java
@@ -1,12 +1,12 @@
 package com.thirdparty.ticketing.global.config;
 
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingAspect;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.common.EventPublisher;
+import com.thirdparty.ticketing.domain.waitingsystem.WaitingAspect;
 import com.thirdparty.ticketing.domain.waitingsystem.WaitingSystem;
 import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;

--- a/src/main/java/com/thirdparty/ticketing/global/config/WaitingConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/WaitingConfig.java
@@ -1,5 +1,6 @@
 package com.thirdparty.ticketing.global.config;
 
+import com.thirdparty.ticketing.domain.waitingsystem.WaitingAspect;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -19,6 +20,11 @@ import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingR
 
 @Configuration
 public class WaitingConfig {
+
+    @Bean
+    public WaitingAspect waitingAspect(WaitingSystem waitingSystem) {
+        return new WaitingAspect(waitingSystem);
+    }
 
     @Bean
     public WaitingSystem waitingSystem(

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
@@ -1,0 +1,121 @@
+package com.thirdparty.ticketing.domain.waitingsystem;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.waitingsystem.WaitingAspectTest.TestController;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestController.class)
+class WaitingAspectTest extends TestContainerStarter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private RedisRunningRoom runningRoom;
+
+    @RestController
+    static class TestController {
+
+        @Waiting
+        @GetMapping("/api/waiting/test")
+        public ResponseEntity<String> test() {
+            return ResponseEntity.ok("test");
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.getConnectionFactory()
+                .getConnection()
+                .commands()
+                .flushAll();
+    }
+
+    private String getBearerToken(Member member) {
+        return "Bearer " + jwtProvider.createAccessToken(member);
+    }
+
+    @Nested
+    @DisplayName("대기열 시스템 AOP 적용 시")
+    class WaitingSystemAop {
+
+        @Test
+        @DisplayName("사용자가 작업 가능 공간에 없으면 리다이렉트한다.")
+        void redirect_WhenRunningRoomNotContainsMember() throws Exception {
+            //given
+            Member member = Member.builder()
+                    .email("email@email.com")
+                    .password("asdfasdf")
+                    .memberRole(MemberRole.USER)
+                    .build();
+            String bearerToken = getBearerToken(member);
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/waiting/test")
+                    .header("performanceId", 1)
+                    .header(AUTHORIZATION_HEADER, bearerToken));
+
+            //then
+            result.andExpect(status().isTemporaryRedirect());
+        }
+
+        @Test
+        @DisplayName("사용자가 작업 가능 공간에 있으면 본래의 기능을 실행한다.")
+        void proceed_WhenRunningRoomContainsMember() throws Exception {
+            //given
+            long performanceId = 1;
+            Member member = Member.builder()
+                    .email("email@email.com")
+                    .password("asdfasdf")
+                    .memberRole(MemberRole.USER)
+                    .build();
+            String bearerToken = getBearerToken(member);
+            runningRoom.enter(performanceId, Set.of(new WaitingMember(
+                    member.getEmail(),
+                    performanceId,
+                    1,
+                    ZonedDateTime.now())));
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/waiting/test")
+                    .header("performanceId", performanceId)
+                    .header(AUTHORIZATION_HEADER, bearerToken));
+
+            //then
+            result.andExpect(status().isOk());
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
@@ -3,15 +3,9 @@ package com.thirdparty.ticketing.domain.waitingsystem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.member.Member;
-import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.domain.member.service.JwtProvider;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingAspectTest.TestController;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +21,14 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.waitingsystem.WaitingAspectTest.TestController;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+
 @SpringBootTest
 @AutoConfigureMockMvc
 @Import(TestController.class)
@@ -34,17 +36,13 @@ class WaitingAspectTest extends TestContainerStarter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
-    @Autowired
-    private JwtProvider jwtProvider;
+    @Autowired private JwtProvider jwtProvider;
 
-    @Autowired
-    private MockMvc mockMvc;
+    @Autowired private MockMvc mockMvc;
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+    @Autowired private StringRedisTemplate redisTemplate;
 
-    @Autowired
-    private RedisRunningRoom runningRoom;
+    @Autowired private RedisRunningRoom runningRoom;
 
     @RestController
     static class TestController {
@@ -58,10 +56,7 @@ class WaitingAspectTest extends TestContainerStarter {
 
     @BeforeEach
     void setUp() {
-        redisTemplate.getConnectionFactory()
-                .getConnection()
-                .commands()
-                .flushAll();
+        redisTemplate.getConnectionFactory().getConnection().commands().flushAll();
     }
 
     private String getBearerToken(Member member) {
@@ -75,46 +70,52 @@ class WaitingAspectTest extends TestContainerStarter {
         @Test
         @DisplayName("사용자가 작업 가능 공간에 없으면 리다이렉트한다.")
         void redirect_WhenRunningRoomNotContainsMember() throws Exception {
-            //given
-            Member member = Member.builder()
-                    .email("email@email.com")
-                    .password("asdfasdf")
-                    .memberRole(MemberRole.USER)
-                    .build();
+            // given
+            Member member =
+                    Member.builder()
+                            .email("email@email.com")
+                            .password("asdfasdf")
+                            .memberRole(MemberRole.USER)
+                            .build();
             String bearerToken = getBearerToken(member);
 
-            //when
-            ResultActions result = mockMvc.perform(get("/api/waiting/test")
-                    .header("performanceId", 1)
-                    .header(AUTHORIZATION_HEADER, bearerToken));
+            // when
+            ResultActions result =
+                    mockMvc.perform(
+                            get("/api/waiting/test")
+                                    .header("performanceId", 1)
+                                    .header(AUTHORIZATION_HEADER, bearerToken));
 
-            //then
+            // then
             result.andExpect(status().isTemporaryRedirect());
         }
 
         @Test
         @DisplayName("사용자가 작업 가능 공간에 있으면 본래의 기능을 실행한다.")
         void proceed_WhenRunningRoomContainsMember() throws Exception {
-            //given
+            // given
             long performanceId = 1;
-            Member member = Member.builder()
-                    .email("email@email.com")
-                    .password("asdfasdf")
-                    .memberRole(MemberRole.USER)
-                    .build();
+            Member member =
+                    Member.builder()
+                            .email("email@email.com")
+                            .password("asdfasdf")
+                            .memberRole(MemberRole.USER)
+                            .build();
             String bearerToken = getBearerToken(member);
-            runningRoom.enter(performanceId, Set.of(new WaitingMember(
-                    member.getEmail(),
+            runningRoom.enter(
                     performanceId,
-                    1,
-                    ZonedDateTime.now())));
+                    Set.of(
+                            new WaitingMember(
+                                    member.getEmail(), performanceId, 1, ZonedDateTime.now())));
 
-            //when
-            ResultActions result = mockMvc.perform(get("/api/waiting/test")
-                    .header("performanceId", performanceId)
-                    .header(AUTHORIZATION_HEADER, bearerToken));
+            // when
+            ResultActions result =
+                    mockMvc.perform(
+                            get("/api/waiting/test")
+                                    .header("performanceId", performanceId)
+                                    .header(AUTHORIZATION_HEADER, bearerToken));
 
-            //then
+            // then
             result.andExpect(status().isOk());
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
@@ -12,7 +12,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -20,35 +19,36 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.thirdparty.ticketing.support.BaseControllerTest;
+
 @WebMvcTest(controllers = WaitingController.class)
 class WaitingControllerTest extends BaseControllerTest {
 
-    @MockBean
-    private WaitingSystem waitingSystem;
+    @MockBean private WaitingSystem waitingSystem;
 
     @Test
     @DisplayName("남은 대기 순번 조회 API 호출 시")
     void getRemainingCount() throws Exception {
-        //given
-        given(waitingSystem.getRemainingCount(anyString(), anyLong()))
-                .willReturn(1L);
+        // given
+        given(waitingSystem.getRemainingCount(anyString(), anyLong())).willReturn(1L);
 
-        //when
-        ResultActions result = mockMvc.perform(get("/api/performances/{performanceId}/wait", 1)
-                .header(AUTHORIZATION_HEADER, userBearerToken));
+        // when
+        ResultActions result =
+                mockMvc.perform(
+                        get("/api/performances/{performanceId}/wait", 1)
+                                .header(AUTHORIZATION_HEADER, userBearerToken));
 
-        //then
+        // then
         result.andExpect(status().isOk())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("performanceId").description("공연 ID")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("remainingCount").type(JsonFieldType.NUMBER).description("남은 대기 순번")
-                        )
-                ));
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("performanceId").description("공연 ID")),
+                                requestHeaders(
+                                        headerWithName("Authorization").description("액세스 토큰")),
+                                responseFields(
+                                        fieldWithPath("remainingCount")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("남은 대기 순번"))));
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
@@ -1,0 +1,54 @@
+package com.thirdparty.ticketing.domain.waitingsystem;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.thirdparty.ticketing.support.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(controllers = WaitingController.class)
+class WaitingControllerTest extends BaseControllerTest {
+
+    @MockBean
+    private WaitingSystem waitingSystem;
+
+    @Test
+    @DisplayName("남은 대기 순번 조회 API 호출 시")
+    void getRemainingCount() throws Exception {
+        //given
+        given(waitingSystem.getRemainingCount(anyString(), anyLong()))
+                .willReturn(1L);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/api/performances/{performanceId}/wait", 1)
+                .header(AUTHORIZATION_HEADER, userBearerToken));
+
+        //then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("performanceId").description("공연 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("remainingCount").type(JsonFieldType.NUMBER).description("남은 대기 순번")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -2,6 +2,10 @@ package com.thirdparty.ticketing.domain.waitingsystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.support.SpyEventPublisher;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -10,27 +14,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
-import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
-import com.thirdparty.ticketing.support.SpyEventPublisher;
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
 @SpringBootTest
-@Import(TestRedisConfig.class)
 class WaitingSystemTest extends TestContainerStarter {
 
-    @Autowired private WaitingSystem waitingSystem;
+    private WaitingSystem waitingSystem;
 
     @Autowired private WaitingManager waitingManager;
 
     @Autowired private RunningManager runningManager;
 
-    @Autowired private SpyEventPublisher eventPublisher;
+    private SpyEventPublisher eventPublisher;
 
     @Autowired private StringRedisTemplate redisTemplate;
 
@@ -38,6 +34,8 @@ class WaitingSystemTest extends TestContainerStarter {
 
     @BeforeEach
     void setUp() {
+        eventPublisher = new SpyEventPublisher();
+        waitingSystem = new WaitingSystem(waitingManager, runningManager, eventPublisher);
         rawRunningCounter = redisTemplate.opsForValue();
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -2,10 +2,6 @@ package com.thirdparty.ticketing.domain.waitingsystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
-import com.thirdparty.ticketing.support.SpyEventPublisher;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,6 +12,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.support.SpyEventPublisher;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 class WaitingSystemTest extends TestContainerStarter {

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
@@ -3,18 +3,12 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.common.ErrorCode;
-import com.thirdparty.ticketing.domain.common.TicketingException;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,6 +18,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 class RedisWaitingManagerTest extends TestContainerStarter {

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
@@ -3,34 +3,29 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.core.HashOperations;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.common.ErrorCode;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
-import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
 import com.thirdparty.ticketing.support.TestContainerStarter;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 
 @SpringBootTest
-@Import(TestRedisConfig.class)
 class RedisWaitingManagerTest extends TestContainerStarter {
 
     @Autowired private RedisWaitingManager waitingManager;

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
@@ -2,12 +2,9 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,6 +13,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 class RedisWaitingRoomTest extends TestContainerStarter {

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
@@ -2,27 +2,22 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
-import com.thirdparty.ticketing.global.waitingsystem.redis.TestRedisConfig;
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
 @SpringBootTest
-@Import(TestRedisConfig.class)
 class RedisWaitingRoomTest extends TestContainerStarter {
 
     @Autowired private RedisWaitingRoom waitingRoom;


### PR DESCRIPTION
### ⛏ 작업 사항
- 대기열 시스템 AOP를 완성했습니다.
  - 작업 가능 공간에 사용자가 존재하지 않으면 대기열에 사용자를 집어넣은 후 307 응답을 반환합니다.
  - 존재한다면 정상 기능을 실행합니다.
- 남은 대기 순번 조회 API 검증을 추가했습니다.

### 📝 작업 요약
- 대기열 시스템 AOP 구현
- 남은 대기 순번 조회 API 검증 추가

### 💡 관련 이슈
- close #97 
