### PR TITLE
Feature: 작업 가능 공간의 회원 정보는 5분 후 만료된다.

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/common/GlobalExceptionHandler.java
@@ -16,7 +16,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TicketingException.class)
     public ResponseEntity<ErrorResponse<Void>> handleTicketingException(TicketingException e) {
         ErrorCode errorCode = e.getErrorCode();
-        log.warn("예외 발생. 메세지={}", e.getMessage(), e);
+        log.warn("예외 발생. 메세지={}", errorCode.getMessage());
         return ResponseEntity.status(errorCode.getHttpStatusValue())
                 .body(ErrorResponse.of(errorCode));
     }

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
@@ -32,6 +32,7 @@ public class WaitingSystem {
     }
 
     public void moveUserToRunning(long performanceId) {
+        runningManager.removeExpiredMemberInfo(performanceId);
         long availableToRunning = runningManager.getAvailableToRunning(performanceId);
         Set<WaitingMember> waitingMembers =
                 waitingManager.pullOutMembers(performanceId, availableToRunning);

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
@@ -14,4 +14,6 @@ public interface RunningManager {
     void enterRunningRoom(long performanceId, Set<WaitingMember> waitingMembers);
 
     void pullOutRunningMember(String email, long performanceId);
+
+    void removeExpiredMemberInfo(long performanceId);
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -41,6 +41,6 @@ public class MemoryRunningManager implements RunningManager {
 
     @Override
     public void removeExpiredMemberInfo(long performanceId) {
-
+        runningRoom.removeExpiredMemberInfo(performanceId);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -38,4 +38,9 @@ public class MemoryRunningManager implements RunningManager {
     public void pullOutRunningMember(String email, long performanceId) {
         runningRoom.pullOutRunningMember(email, performanceId);
     }
+
+    @Override
+    public void removeExpiredMemberInfo(long performanceId) {
+
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
@@ -1,11 +1,13 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.running;
 
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningRoom;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.time.ZonedDateTime;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningRoom;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -51,14 +53,16 @@ public class MemoryRunningRoom implements RunningRoom {
     }
 
     public void removeExpiredMemberInfo(long performanceId) {
-        room.computeIfPresent(performanceId,
+        room.computeIfPresent(
+                performanceId,
                 (key, room) -> {
                     ZonedDateTime fiveMinutesAgo = ZonedDateTime.now().minusMinutes(EXPIRED_MINUTE);
                     room.values().stream()
                             .filter(member -> member.getEnteredAt().isBefore(fiveMinutesAgo))
-                            .forEach(member -> {
-                                room.remove(member.getEmail());
-                            });
+                            .forEach(
+                                    member -> {
+                                        room.remove(member.getEmail());
+                                    });
                     return room;
                 });
     }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -39,4 +39,8 @@ public class RedisRunningManager implements RunningManager {
     public void pullOutRunningMember(String email, long performanceId) {
         runningRoom.pullOutRunningMember(email, performanceId);
     }
+
+    @Override
+    public void removeExpiredMemberInfo(long performanceId) {
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -42,5 +42,6 @@ public class RedisRunningManager implements RunningManager {
 
     @Override
     public void removeExpiredMemberInfo(long performanceId) {
+        runningRoom.removeExpiredMemberInfo(performanceId);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -16,6 +16,7 @@ public class RedisRunningRoom implements RunningRoom {
 
     private static final int MAX_RUNNING_ROOM_SIZE = 100;
     private static final String RUNNING_ROOM_KEY = "running_room:";
+    private static final int EXPIRED_MINUTE = 5;
 
     private final ZSetOperations<String, String> runningRoom;
 
@@ -53,5 +54,13 @@ public class RedisRunningRoom implements RunningRoom {
 
     public void pullOutRunningMember(String email, long performanceId) {
         runningRoom.remove(getRunningRoomKey(performanceId), email);
+    }
+
+    public void removeExpiredMemberInfo(long performanceId) {
+        long removeRange = ZonedDateTime.now().minusMinutes(EXPIRED_MINUTE).toEpochSecond();
+        runningRoom.removeRangeByScore(
+                getRunningRoomKey(performanceId),
+                0,
+                removeRange);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -58,9 +58,6 @@ public class RedisRunningRoom implements RunningRoom {
 
     public void removeExpiredMemberInfo(long performanceId) {
         long removeRange = ZonedDateTime.now().minusMinutes(EXPIRED_MINUTE).toEpochSecond();
-        runningRoom.removeRangeByScore(
-                getRunningRoomKey(performanceId),
-                0,
-                removeRange);
+        runningRoom.removeRangeByScore(getRunningRoomKey(performanceId), 0, removeRange);
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -2,11 +2,8 @@ package com.thirdparty.ticketing.domain.waitingsystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
-import com.thirdparty.ticketing.support.SpyEventPublisher;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +15,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
+
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.support.SpyEventPublisher;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 class WaitingSystemTest extends TestContainerStarter {
@@ -57,7 +59,6 @@ class WaitingSystemTest extends TestContainerStarter {
     @DisplayName("사용자의 남은 순번 조회 시")
     class GetRemainingCountTest {
 
-
         @ParameterizedTest
         @CsvSource({"0, 0, 1", "15, 10, 6"})
         @DisplayName("자신이 몇 번째 차례인지 반환한다.")
@@ -77,6 +78,7 @@ class WaitingSystemTest extends TestContainerStarter {
             // then
             assertThat(remainingCount).isEqualTo(expected);
         }
+
         @Test
         @DisplayName("폴링 이벤트를 발행한다.")
         void publishPollingEvent() {
@@ -91,26 +93,25 @@ class WaitingSystemTest extends TestContainerStarter {
             // then
             assertThat(eventPublisher.counter).hasValue(1);
         }
-
     }
+
     @Nested
     @DisplayName("대기열 사용자 작업 가능 공간 이동 호출 시")
     class MoveUserToRunningTest {
 
-
         @Test
         @DisplayName("작업 공간의 작업 시간이 만료된 사용자를 제거한다.")
         void removeExpiredMemberInfo() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             long score = ZonedDateTime.now().minusMinutes(5).toEpochSecond();
             rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
 
-            //when
+            // when
             waitingSystem.moveUserToRunning(performanceId);
 
-            //then
+            // then
             assertThat(runningManager.isReadyToHandle(email, performanceId)).isFalse();
         }
 
@@ -132,6 +133,7 @@ class WaitingSystemTest extends TestContainerStarter {
             assertThat(runningManager.getAvailableToRunning(performanceId))
                     .isEqualTo(100 - memberCount);
         }
+
         @Test
         @DisplayName("더 이상 인원을 수용할 수 없으면 작업 가능 공간에 사용자를 추가하지 않는다.")
         void doNotMoveUserToRunning_WhenNoMoreAvailableSpace() {

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import com.thirdparty.ticketing.domain.common.EventPublisher;
 import com.thirdparty.ticketing.domain.waitingsystem.WaitingSystem;
@@ -26,11 +26,11 @@ class WaitingEventListenerTest extends TestContainerStarter {
 
     @Autowired private StringRedisTemplate redisTemplate;
 
-    private SetOperations<String, String> rawRunningRoom;
+    private ZSetOperations<String, String> rawRunningRoom;
 
     @BeforeEach
     void setUp() {
-        rawRunningRoom = redisTemplate.opsForSet();
+        rawRunningRoom = redisTemplate.opsForZSet();
         redisTemplate.getConnectionFactory().getConnection().commands().flushAll();
     }
 
@@ -51,7 +51,7 @@ class WaitingEventListenerTest extends TestContainerStarter {
             waitingSystem.getRemainingCount(email, performanceId);
 
             // then
-            Set<String> members = rawRunningRoom.members("running_room:" + performanceId);
+            Set<String> members = rawRunningRoom.range("running_room:" + performanceId, 0, -1);
             System.out.println("회원 목록 출력 " + members);
             assertThat(waitingSystem.isReadyToHandle(email, performanceId)).isTrue();
         }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
@@ -176,4 +176,43 @@ class MemoryRunningRoomTest {
             assertThat(room.get(performanceId)).hasSize(1);
         }
     }
+
+    @Nested
+    @DisplayName("만료된 사용자 제거 호출 시")
+    class RemoveExpiredMemberInfoTest {
+
+        @Test
+        @DisplayName("입장한지 5분이 지난 사용자 정보를 제거한다.")
+        void removeExpiredMemberInfo() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            ZonedDateTime fiveMinuteAgo = ZonedDateTime.now().minusMinutes(5).minusSeconds(1);
+            WaitingMember waitingMember = new WaitingMember(email, performanceId, 1, fiveMinuteAgo);
+            runningRoom.enter(performanceId, Set.of(waitingMember));
+
+            //when
+            runningRoom.removeExpiredMemberInfo(performanceId);
+
+            //then
+            assertThat(room.get(performanceId).get(email)).isNull();
+        }
+
+        @Test
+        @DisplayName("입장한지 5분이 지나지 않은 사용자 정보는 제거하지 않는다.")
+        void notRemoveMemberInfo() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            ZonedDateTime nearFiveMinuteAgo = ZonedDateTime.now().minusMinutes(5).plusSeconds(2);
+            WaitingMember waitingMember = new WaitingMember(email, performanceId, 1, nearFiveMinuteAgo);
+            runningRoom.enter(performanceId, Set.of(waitingMember));
+
+            //when
+            runningRoom.removeExpiredMemberInfo(performanceId);
+
+            //then
+            assertThat(room.get(performanceId).get(email)).isEqualTo(waitingMember);
+        }
+    }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
@@ -184,34 +184,35 @@ class MemoryRunningRoomTest {
         @Test
         @DisplayName("입장한지 5분이 지난 사용자 정보를 제거한다.")
         void removeExpiredMemberInfo() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             ZonedDateTime fiveMinuteAgo = ZonedDateTime.now().minusMinutes(5).minusSeconds(1);
             WaitingMember waitingMember = new WaitingMember(email, performanceId, 1, fiveMinuteAgo);
             runningRoom.enter(performanceId, Set.of(waitingMember));
 
-            //when
+            // when
             runningRoom.removeExpiredMemberInfo(performanceId);
 
-            //then
+            // then
             assertThat(room.get(performanceId).get(email)).isNull();
         }
 
         @Test
         @DisplayName("입장한지 5분이 지나지 않은 사용자 정보는 제거하지 않는다.")
         void notRemoveMemberInfo() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             ZonedDateTime nearFiveMinuteAgo = ZonedDateTime.now().minusMinutes(5).plusSeconds(2);
-            WaitingMember waitingMember = new WaitingMember(email, performanceId, 1, nearFiveMinuteAgo);
+            WaitingMember waitingMember =
+                    new WaitingMember(email, performanceId, 1, nearFiveMinuteAgo);
             runningRoom.enter(performanceId, Set.of(waitingMember));
 
-            //when
+            // when
             runningRoom.removeExpiredMemberInfo(performanceId);
 
-            //then
+            // then
             assertThat(room.get(performanceId).get(email)).isEqualTo(waitingMember);
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.support.TestContainerStarter;
@@ -27,12 +27,12 @@ class RedisRunningManagerTest extends TestContainerStarter {
     @Autowired private StringRedisTemplate redisTemplate;
 
     private ValueOperations<String, String> rawRunningCounter;
-    private SetOperations<String, String> rawRunningRoom;
+    private ZSetOperations<String, String> rawRunningRoom;
 
     @BeforeEach
     void setUp() {
         rawRunningCounter = redisTemplate.opsForValue();
-        rawRunningRoom = redisTemplate.opsForSet();
+        rawRunningRoom = redisTemplate.opsForZSet();
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
@@ -163,7 +163,8 @@ class RedisRunningManagerTest extends TestContainerStarter {
             runningManager.enterRunningRoom(performanceId, waitingMembers);
 
             // then
-            Set<String> waitingMembers = rawRunningRoom.members(getRunningRoomKey(performanceId));
+            Set<String> waitingMembers =
+                    rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1);
             assertThat(waitingMembers).hasSize(waitingMemberCount);
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -206,33 +206,32 @@ class RedisRunningRoomTest extends TestContainerStarter {
         @Test
         @DisplayName("입장한지 5분이 지난 사용자 정보를 제거한다.")
         void removeExpiredMemberInfo() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             long score = ZonedDateTime.now().minusMinutes(5).minusSeconds(1).toEpochSecond();
             rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
 
-            //when
+            // when
             runningRoom.removeExpiredMemberInfo(performanceId);
 
-            //then
-            assertThat(rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1))
-                    .isEmpty();
+            // then
+            assertThat(rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1)).isEmpty();
         }
 
         @Test
         @DisplayName("입장한지 5분이 지나지 않은 사용자 정보는 제거하지 않는다.")
         void notRemoveMemberInfo() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             long score = ZonedDateTime.now().minusMinutes(5).plusSeconds(10).toEpochSecond();
             rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
 
-            //when
+            // when
             runningRoom.removeExpiredMemberInfo(performanceId);
 
-            //then
+            // then
             assertThat(rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1))
                     .hasSize(1)
                     .first()

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -198,4 +198,45 @@ class RedisRunningRoomTest extends TestContainerStarter {
             assertThat(runningRoom.contains(email, performanceId)).isFalse();
         }
     }
+
+    @Nested
+    @DisplayName("만료된 사용자 제거 호출 시")
+    class RemoveExpiredMemberInfoTest {
+
+        @Test
+        @DisplayName("입장한지 5분이 지난 사용자 정보를 제거한다.")
+        void removeExpiredMemberInfo() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            long score = ZonedDateTime.now().minusMinutes(5).minusSeconds(1).toEpochSecond();
+            rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
+
+            //when
+            runningRoom.removeExpiredMemberInfo(performanceId);
+
+            //then
+            assertThat(rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("입장한지 5분이 지나지 않은 사용자 정보는 제거하지 않는다.")
+        void notRemoveMemberInfo() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            long score = ZonedDateTime.now().minusMinutes(5).plusSeconds(10).toEpochSecond();
+            rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
+
+            //when
+            runningRoom.removeExpiredMemberInfo(performanceId);
+
+            //then
+            assertThat(rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1))
+                    .hasSize(1)
+                    .first()
+                    .isEqualTo(email);
+        }
+    }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZonedDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,8 +15,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.support.TestContainerStarter;
@@ -27,11 +28,11 @@ class RedisRunningRoomTest extends TestContainerStarter {
 
     @Autowired private StringRedisTemplate redisTemplate;
 
-    private SetOperations<String, String> rawRunningRoom;
+    private ZSetOperations<String, String> rawRunningRoom;
 
     @BeforeEach
     void setUp() {
-        rawRunningRoom = redisTemplate.opsForSet();
+        rawRunningRoom = redisTemplate.opsForZSet();
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
@@ -49,7 +50,8 @@ class RedisRunningRoomTest extends TestContainerStarter {
             // given
             long performanceId = 1;
             String email = "email@email.com";
-            rawRunningRoom.add(getRunningRoomKey(performanceId), email);
+            rawRunningRoom.add(
+                    getRunningRoomKey(performanceId), email, ZonedDateTime.now().toEpochSecond());
 
             // when
             boolean contains = runningRoom.contains(email, performanceId);
@@ -79,7 +81,8 @@ class RedisRunningRoomTest extends TestContainerStarter {
             long performanceIdA = 1;
             long performanceIdB = 2;
             String email = "email@email.com";
-            rawRunningRoom.add(getRunningRoomKey(performanceIdA), email);
+            rawRunningRoom.add(
+                    getRunningRoomKey(performanceIdA), email, ZonedDateTime.now().toEpochSecond());
 
             // when
             boolean contains = runningRoom.contains(email, performanceIdB);
@@ -100,7 +103,10 @@ class RedisRunningRoomTest extends TestContainerStarter {
             // given
             long performanceId = 1;
             for (int i = 0; i < runningMembers; i++) {
-                rawRunningRoom.add(getRunningRoomKey(performanceId), "email" + i + "@email.com");
+                rawRunningRoom.add(
+                        getRunningRoomKey(performanceId),
+                        "email" + i + "@email.com",
+                        ZonedDateTime.now().toEpochSecond());
             }
 
             // when
@@ -133,8 +139,8 @@ class RedisRunningRoomTest extends TestContainerStarter {
             // then
             String[] emails =
                     waitingMembers.stream().map(WaitingMember::getEmail).toArray(String[]::new);
-            assertThat(rawRunningRoom.isMember(getRunningRoomKey(performanceId), emails))
-                    .allSatisfy((key, value) -> assertThat(value).isTrue());
+            List<Double> score = rawRunningRoom.score(getRunningRoomKey(performanceId), emails);
+            assertThat(score).allSatisfy(value -> assertThat(value).isNotNull());
         }
     }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 러닝룸(작업 공간)의 사용자 정보가 5분후 만료되는 로직을 구현하였습니다.
- 레디스 러닝룸의 경우 구현의 용이성을 위해 기존 set 을 사용하던 것에서 sortedSet으로 변경하였습니다.
  - sortedSet의 score 기준으로 정렬 되는 특성을 이용해 러닝룸 입장 시간을 score로 사용했습니다.
- 대기열 사용자 추출 -> 작업 공간 이동 로직 실행 시 가장 먼저 만료대상인 사용자들을 제거하는 로직 부터 실행됩니다.

### 📝 작업 요약
- 작업 공간에 입장하고 5분이 지난 사용자 정보 만료 로직 구현

### 💡 관련 이슈
- close #130 
