### PR TITLE
Feature: 사용자가 예매 사이트를 벗어나면 대기 정보가 삭제된다.

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/Debounce.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/Debounce.java
@@ -1,4 +1,4 @@
-package com.thirdparty.ticketing.global.waitingsystem;
+package com.thirdparty.ticketing.domain.waitingsystem;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/DebounceAspect.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/DebounceAspect.java
@@ -1,4 +1,4 @@
-package com.thirdparty.ticketing.global.waitingsystem.redis;
+package com.thirdparty.ticketing.domain.waitingsystem;
 
 import java.util.concurrent.TimeUnit;
 
@@ -25,7 +25,7 @@ public class DebounceAspect {
         debounce = redisTemplate.opsForValue();
     }
 
-    @Pointcut("@annotation(com.thirdparty.ticketing.global.waitingsystem.Debounce)")
+    @Pointcut("@annotation(com.thirdparty.ticketing.domain.waitingsystem.Debounce)")
     private void debounceAnnotation() {}
 
     @Pointcut(

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
@@ -1,16 +1,14 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
+import com.thirdparty.ticketing.domain.common.LoginMember;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.thirdparty.ticketing.domain.common.LoginMember;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +22,12 @@ public class WaitingController {
             @LoginMember String email, @PathVariable("performanceId") Long performanceId) {
         long remainingCount = waitingSystem.getRemainingCount(email, performanceId);
         return ResponseEntity.ok(Map.of("remainingCount", remainingCount));
+    }
+
+    @DeleteMapping("/performances/{performanceId}/wait")
+    public ResponseEntity<Void> removeMemberInfo(
+            @LoginMember String email, @PathVariable("performanceId") Long performanceId) {
+        waitingSystem.pullOutRunningMember(email, performanceId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingController.java
@@ -1,14 +1,17 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
-import com.thirdparty.ticketing.domain.common.LoginMember;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.thirdparty.ticketing.domain.common.LoginMember;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspect.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspect.java
@@ -30,7 +30,7 @@ public class MemoryDebounceAspect {
         }
     }
 
-    @Pointcut("@annotation(com.thirdparty.ticketing.global.waitingsystem.Debounce)")
+    @Pointcut("@annotation(com.thirdparty.ticketing.domain.waitingsystem.Debounce)")
     private void debounceAnnotation() {}
 
     @Pointcut(

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -4,10 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.thirdparty.ticketing.domain.common.TicketingException;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import java.time.ZonedDateTime;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,8 +19,10 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
 
+import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.support.SpyEventPublisher;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
@@ -169,17 +170,18 @@ class WaitingSystemTest extends TestContainerStarter {
         @Test
         @DisplayName("대기열 시스템에서 사용자 정보를 제거한다.")
         void pullOutMember() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             waitingManager.enterWaitingRoom(email, performanceId);
-            WaitingMember waitingMember = new WaitingMember(email, performanceId, 1, ZonedDateTime.now());
+            WaitingMember waitingMember =
+                    new WaitingMember(email, performanceId, 1, ZonedDateTime.now());
             runningManager.enterRunningRoom(performanceId, Set.of(waitingMember));
 
-            //when
+            // when
             waitingSystem.pullOutRunningMember(email, performanceId);
 
-            //then
+            // then
             assertThat(runningManager.isReadyToHandle(email, performanceId)).isFalse();
             assertThatThrownBy(() -> waitingManager.findWaitingMember(email, performanceId))
                     .isInstanceOf(TicketingException.class);
@@ -188,14 +190,15 @@ class WaitingSystemTest extends TestContainerStarter {
         @Test
         @DisplayName("사용자 정보가 없으면 무시한다.")
         void ignore_WhenMemberInfoNotExists() {
-            //given
+            // given
             String email = "email@email.com";
             long performanceId = 1;
 
-            //when
-            Exception exception = catchException(() -> waitingSystem.pullOutRunningMember(email, performanceId));
+            // when
+            Exception exception =
+                    catchException(() -> waitingSystem.pullOutRunningMember(email, performanceId));
 
-            //then
+            // then
             assertThat(exception).doesNotThrowAnyException();
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspectTest.java
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.thirdparty.ticketing.global.waitingsystem.Debounce;
+import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
 
 @ExtendWith(SpringExtension.class)
 @Import(MemoryDebounceAspectTest.MemoryDebounceAopConfig.class)

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/DebounceAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/DebounceAspectTest.java
@@ -16,7 +16,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-import com.thirdparty.ticketing.global.waitingsystem.Debounce;
+import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
 import com.thirdparty.ticketing.global.waitingsystem.redis.DebounceAspectTest.TestConfig;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 기존 사용자 정보 제거 기능을 사용하여 구현하였습니다.
- 나가기 버튼 클릭 시 작업 공간, 대기방에서 사용자 정보를 제거하는 API를 추가했습니다.

### 📝 작업 요약
- 대기열 시스템 나가기 API 구현

### 💡 관련 이슈
- close #134 
