### PR TITLE
Fix: 작업 정보가 만료된 사용자 정보가 대기방에서 제거되지 않는 문제를 수정한다.

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
@@ -32,7 +32,8 @@ public class WaitingSystem {
     }
 
     public void moveUserToRunning(long performanceId) {
-        runningManager.removeExpiredMemberInfo(performanceId);
+        Set<String> removeMemberEmails = runningManager.removeExpiredMemberInfo(performanceId);
+        waitingManager.removeMemberInfo(removeMemberEmails, performanceId);
         long availableToRunning = runningManager.getAvailableToRunning(performanceId);
         Set<WaitingMember> waitingMembers =
                 waitingManager.pullOutMembers(performanceId, availableToRunning);

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
@@ -15,5 +15,5 @@ public interface RunningManager {
 
     void pullOutRunningMember(String email, long performanceId);
 
-    void removeExpiredMemberInfo(long performanceId);
+    Set<String> removeExpiredMemberInfo(long performanceId);
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingManager.java
@@ -10,4 +10,6 @@ public interface WaitingManager {
     Set<WaitingMember> pullOutMembers(long performanceId, long availableToRunning);
 
     void removeMemberInfo(String email, long performanceId);
+
+    void removeMemberInfo(Set<String> emails, long performanceId);
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingMember.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/waiting/WaitingMember.java
@@ -33,4 +33,8 @@ public class WaitingMember {
         this.waitingCount = waitingCount;
         this.enteredAt = enteredAt;
     }
+
+    public void enter() {
+        this.enteredAt = ZonedDateTime.now();
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -30,6 +30,7 @@ public class MemoryRunningManager implements RunningManager {
 
     @Override
     public void enterRunningRoom(long performanceId, Set<WaitingMember> waitingMembers) {
+        waitingMembers.forEach(WaitingMember::enter);
         runningCounter.increment(performanceId, waitingMembers.size());
         runningRoom.enter(performanceId, waitingMembers);
     }
@@ -40,7 +41,7 @@ public class MemoryRunningManager implements RunningManager {
     }
 
     @Override
-    public void removeExpiredMemberInfo(long performanceId) {
-        runningRoom.removeExpiredMemberInfo(performanceId);
+    public Set<String> removeExpiredMemberInfo(long performanceId) {
+        return runningRoom.removeExpiredMemberInfo(performanceId);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
@@ -5,11 +5,11 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import com.thirdparty.ticketing.domain.waitingsystem.running.RunningRoom;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -56,15 +56,16 @@ public class MemoryRunningRoom implements RunningRoom {
 
     public Set<String> removeExpiredMemberInfo(long performanceId) {
         ConcurrentMap<String, WaitingMember> performanceRoom = room.get(performanceId);
-        if(performanceRoom == null) {
+        if (performanceRoom == null) {
             return Set.of();
         }
 
         ZonedDateTime fiveMinutesAgo = ZonedDateTime.now().minusMinutes(EXPIRED_MINUTE);
-        Set<String> removeMemberEmails = performanceRoom.entrySet().stream()
-                .filter(entry -> entry.getValue().getEnteredAt().isBefore(fiveMinutesAgo))
-                .map(Entry::getKey)
-                .collect(Collectors.toSet());
+        Set<String> removeMemberEmails =
+                performanceRoom.entrySet().stream()
+                        .filter(entry -> entry.getValue().getEnteredAt().isBefore(fiveMinutesAgo))
+                        .map(Entry::getKey)
+                        .collect(Collectors.toSet());
         removeMemberEmails.forEach(performanceRoom::remove);
         return removeMemberEmails;
     }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingManager.java
@@ -44,4 +44,9 @@ public class MemoryWaitingManager implements WaitingManager {
     public void removeMemberInfo(String email, long performanceId) {
         waitingRoom.removeMemberInfo(email, performanceId);
     }
+
+    @Override
+    public void removeMemberInfo(Set<String> emails, long performanceId) {
+        waitingRoom.removeMemberInfo(emails, performanceId);
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
@@ -1,6 +1,7 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -16,7 +17,7 @@ public class MemoryWaitingRoom implements WaitingRoom {
 
     public boolean enter(String email, long performanceId) {
         return room.computeIfAbsent(performanceId, k -> new ConcurrentHashMap<>())
-                        .putIfAbsent(email, new WaitingMember(email, performanceId))
+                .putIfAbsent(email, new WaitingMember(email, performanceId))
                 == null;
     }
 
@@ -35,6 +36,14 @@ public class MemoryWaitingRoom implements WaitingRoom {
                 (key, waitingRoom) -> {
                     waitingRoom.remove(email);
                     return waitingRoom;
+                });
+    }
+
+    public void removeMemberInfo(Set<String> emails, long performanceId) {
+        room.computeIfPresent(performanceId,
+                (key, room) -> {
+                    emails.forEach(room::remove);
+                    return room;
                 });
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoom.java
@@ -17,7 +17,7 @@ public class MemoryWaitingRoom implements WaitingRoom {
 
     public boolean enter(String email, long performanceId) {
         return room.computeIfAbsent(performanceId, k -> new ConcurrentHashMap<>())
-                .putIfAbsent(email, new WaitingMember(email, performanceId))
+                        .putIfAbsent(email, new WaitingMember(email, performanceId))
                 == null;
     }
 
@@ -40,7 +40,8 @@ public class MemoryWaitingRoom implements WaitingRoom {
     }
 
     public void removeMemberInfo(Set<String> emails, long performanceId) {
-        room.computeIfPresent(performanceId,
+        room.computeIfPresent(
+                performanceId,
                 (key, room) -> {
                     emails.forEach(room::remove);
                     return room;

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -41,7 +41,7 @@ public class RedisRunningManager implements RunningManager {
     }
 
     @Override
-    public void removeExpiredMemberInfo(long performanceId) {
-        runningRoom.removeExpiredMemberInfo(performanceId);
+    public Set<String> removeExpiredMemberInfo(long performanceId) {
+        return runningRoom.removeExpiredMemberInfo(performanceId);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -56,8 +56,11 @@ public class RedisRunningRoom implements RunningRoom {
         runningRoom.remove(getRunningRoomKey(performanceId), email);
     }
 
-    public void removeExpiredMemberInfo(long performanceId) {
+    public Set<String> removeExpiredMemberInfo(long performanceId) {
         long removeRange = ZonedDateTime.now().minusMinutes(EXPIRED_MINUTE).toEpochSecond();
-        runningRoom.removeRangeByScore(getRunningRoomKey(performanceId), 0, removeRange);
+        String runningRoomKey = getRunningRoomKey(performanceId);
+        Set<String> removedMemberEmails = runningRoom.rangeByScore(runningRoomKey, 0, removeRange);
+        runningRoom.removeRangeByScore(runningRoomKey, 0, removeRange);
+        return removedMemberEmails;
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManager.java
@@ -46,4 +46,9 @@ public class RedisWaitingManager implements WaitingManager {
     public void removeMemberInfo(String email, long performanceId) {
         waitingRoom.removeMemberInfo(email, performanceId);
     }
+
+    @Override
+    public void removeMemberInfo(Set<String> emails, long performanceId) {
+        waitingRoom.removeMemberInfo(emails, performanceId);
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
@@ -1,8 +1,8 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import java.util.Optional;
-
 import java.util.Set;
+
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -52,7 +52,7 @@ public class RedisWaitingRoom implements WaitingRoom {
     }
 
     public void removeMemberInfo(Set<String> emails, long performanceId) {
-        if(emails.isEmpty()) {
+        if (emails.isEmpty()) {
             return;
         }
         waitingRoom.delete(getWaitingRoomKey(performanceId), emails.toArray(String[]::new));

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoom.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import java.util.Optional;
 
+import java.util.Set;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -48,5 +49,12 @@ public class RedisWaitingRoom implements WaitingRoom {
 
     public void removeMemberInfo(String email, long performanceId) {
         waitingRoom.delete(getWaitingRoomKey(performanceId), email);
+    }
+
+    public void removeMemberInfo(Set<String> emails, long performanceId) {
+        if(emails.isEmpty()) {
+            return;
+        }
+        waitingRoom.delete(getWaitingRoomKey(performanceId), emails.toArray(String[]::new));
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -4,16 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.common.TicketingException;
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.SpyEventPublisher;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,24 +20,29 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.SpyEventPublisher;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+
 @SpringBootTest
 class WaitingSystemTest extends TestContainerStarter {
 
     private WaitingSystem waitingSystem;
 
-    @Autowired
-    private WaitingManager waitingManager;
+    @Autowired private WaitingManager waitingManager;
 
-    @Autowired
-    private RunningManager runningManager;
+    @Autowired private RunningManager runningManager;
 
     private SpyEventPublisher eventPublisher;
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+    @Autowired private StringRedisTemplate redisTemplate;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    @Autowired private ObjectMapper objectMapper;
 
     private ZSetOperations<String, String> rawRunningRoom;
     private HashOperations<String, String, String> rawWaitingRoom;
@@ -129,7 +127,10 @@ class WaitingSystemTest extends TestContainerStarter {
             score = fiveMinuteAgo.toEpochSecond();
 
             WaitingMember waitingMember = new WaitingMember(email, performanceId, 1, fiveMinuteAgo);
-            rawWaitingRoom.put(getWaitingRoomKey(performanceId), email, objectMapper.writeValueAsString(waitingMember));
+            rawWaitingRoom.put(
+                    getWaitingRoomKey(performanceId),
+                    email,
+                    objectMapper.writeValueAsString(waitingMember));
             rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
         }
 
@@ -146,10 +147,7 @@ class WaitingSystemTest extends TestContainerStarter {
 
             // then
             Set<String> emails = rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1);
-            assertThat(emails)
-                    .hasSize(1)
-                    .first()
-                    .isEqualTo(anotherEmail);
+            assertThat(emails).hasSize(1).first().isEqualTo(anotherEmail);
         }
 
         @Test
@@ -160,17 +158,17 @@ class WaitingSystemTest extends TestContainerStarter {
             ZonedDateTime now = ZonedDateTime.now();
             WaitingMember waitingMember = new WaitingMember(anotherEmail, performanceId, 2, now);
             rawRunningRoom.add(getRunningRoomKey(performanceId), anotherEmail, now.toEpochSecond());
-            rawWaitingRoom.put(getWaitingRoomKey(performanceId), anotherEmail, objectMapper.writeValueAsString(waitingMember));
+            rawWaitingRoom.put(
+                    getWaitingRoomKey(performanceId),
+                    anotherEmail,
+                    objectMapper.writeValueAsString(waitingMember));
 
             // when
             waitingSystem.moveUserToRunning(performanceId);
 
             // then
             Set<String> emails = rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1);
-            assertThat(emails)
-                    .hasSize(1)
-                    .first()
-                    .isEqualTo(anotherEmail);
+            assertThat(emails).hasSize(1).first().isEqualTo(anotherEmail);
         }
 
         @Test

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -4,9 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.SpyEventPublisher;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,32 +22,32 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
-
-import com.thirdparty.ticketing.domain.common.TicketingException;
-import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.SpyEventPublisher;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 class WaitingSystemTest extends TestContainerStarter {
 
     private WaitingSystem waitingSystem;
 
-    @Autowired private WaitingManager waitingManager;
+    @Autowired
+    private WaitingManager waitingManager;
 
-    @Autowired private RunningManager runningManager;
-
-    private ZSetOperations<String, String> rawRunningRoom;
+    @Autowired
+    private RunningManager runningManager;
 
     private SpyEventPublisher eventPublisher;
 
-    @Autowired private StringRedisTemplate redisTemplate;
+    @Autowired
+    private StringRedisTemplate redisTemplate;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private ZSetOperations<String, String> rawRunningRoom;
+    private HashOperations<String, String, String> rawWaitingRoom;
     private ValueOperations<String, String> rawRunningCounter;
 
     @BeforeEach
@@ -49,6 +56,7 @@ class WaitingSystemTest extends TestContainerStarter {
         waitingSystem = new WaitingSystem(waitingManager, runningManager, eventPublisher);
         rawRunningRoom = redisTemplate.opsForZSet();
         rawRunningCounter = redisTemplate.opsForValue();
+        rawWaitingRoom = redisTemplate.opsForHash();
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
@@ -58,6 +66,10 @@ class WaitingSystemTest extends TestContainerStarter {
 
     private String getRunningCounterKey(long performanceId) {
         return "running_counter:" + performanceId;
+    }
+
+    private String getWaitingRoomKey(long performanceId) {
+        return "waiting_room:" + performanceId;
     }
 
     @Nested
@@ -104,27 +116,67 @@ class WaitingSystemTest extends TestContainerStarter {
     @DisplayName("대기열 사용자 작업 가능 공간 이동 호출 시")
     class MoveUserToRunningTest {
 
+        private long performanceId;
+        private String email;
+        private ZonedDateTime fiveMinuteAgo;
+        private long score;
+
+        @BeforeEach
+        void setUp() throws JsonProcessingException {
+            performanceId = 1;
+            email = "email@email.com";
+            fiveMinuteAgo = ZonedDateTime.now().minusMinutes(5);
+            score = fiveMinuteAgo.toEpochSecond();
+
+            WaitingMember waitingMember = new WaitingMember(email, performanceId, 1, fiveMinuteAgo);
+            rawWaitingRoom.put(getWaitingRoomKey(performanceId), email, objectMapper.writeValueAsString(waitingMember));
+            rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
+        }
+
         @Test
         @DisplayName("작업 공간의 작업 시간이 만료된 사용자를 제거한다.")
-        void removeExpiredMemberInfo() {
+        void removeExpiredMemberInfoFromRunningRoom() {
             // given
-            long performanceId = 1;
-            String email = "email@email.com";
-            long score = ZonedDateTime.now().minusMinutes(5).toEpochSecond();
-            rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
+            String anotherEmail = "anotherEmail@email.com";
+            ZonedDateTime now = ZonedDateTime.now();
+            rawRunningRoom.add(getRunningRoomKey(performanceId), anotherEmail, now.toEpochSecond());
 
             // when
             waitingSystem.moveUserToRunning(performanceId);
 
             // then
-            assertThat(runningManager.isReadyToHandle(email, performanceId)).isFalse();
+            Set<String> emails = rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1);
+            assertThat(emails)
+                    .hasSize(1)
+                    .first()
+                    .isEqualTo(anotherEmail);
+        }
+
+        @Test
+        @DisplayName("대기방의 시간이 만료된 사용자를 제거한다.")
+        void removeExpiredMemberInfoFromWaitingRoom() throws JsonProcessingException {
+            // given
+            String anotherEmail = "anotherEmail@email.com";
+            ZonedDateTime now = ZonedDateTime.now();
+            WaitingMember waitingMember = new WaitingMember(anotherEmail, performanceId, 2, now);
+            rawRunningRoom.add(getRunningRoomKey(performanceId), anotherEmail, now.toEpochSecond());
+            rawWaitingRoom.put(getWaitingRoomKey(performanceId), anotherEmail, objectMapper.writeValueAsString(waitingMember));
+
+            // when
+            waitingSystem.moveUserToRunning(performanceId);
+
+            // then
+            Set<String> emails = rawRunningRoom.range(getRunningRoomKey(performanceId), 0, -1);
+            assertThat(emails)
+                    .hasSize(1)
+                    .first()
+                    .isEqualTo(anotherEmail);
         }
 
         @Test
         @DisplayName("작업 가능 공간의 수용 가능한 인원이 감소한다.")
         void decrementAvailableCount() {
             // given
-            long performanceId = 1;
             int memberCount = 25;
             for (int i = 0; i < memberCount; i++) {
                 waitingManager.enterWaitingRoom("email" + i + "@email.com", performanceId);
@@ -143,7 +195,6 @@ class WaitingSystemTest extends TestContainerStarter {
         @DisplayName("더 이상 인원을 수용할 수 없으면 작업 가능 공간에 사용자를 추가하지 않는다.")
         void doNotMoveUserToRunning_WhenNoMoreAvailableSpace() {
             // given
-            long performanceId = 1;
             for (int i = 0; i < 100; i++) {
                 waitingSystem.enterWaitingRoom("email" + i + "@email.com", performanceId);
             }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoomTest.java
@@ -192,17 +192,17 @@ class MemoryWaitingRoomTest {
         @Test
         @DisplayName("사용자 정보가 제거된다.")
         void removeMemberInfo() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             String email2 = "email2@email.com";
             waitingRoom.enter(email, performanceId);
             waitingRoom.enter(email2, performanceId);
 
-            //when
+            // when
             waitingRoom.removeMemberInfo(Set.of(email, email2), performanceId);
 
-            //then
+            // then
             assertThat(waitingRoom.findWaitingMember(email, performanceId)).isEmpty();
             assertThat(waitingRoom.findWaitingMember(email2, performanceId)).isEmpty();
         }
@@ -210,14 +210,16 @@ class MemoryWaitingRoomTest {
         @Test
         @DisplayName("사용자 정보가 대기방에 존재하지 않으면 무시한다.")
         void ignore_WhenNotExistsWaitingRoom() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
 
-            //when
-            Exception exception = catchException(() -> waitingRoom.removeMemberInfo(Set.of(email), performanceId));
+            // when
+            Exception exception =
+                    catchException(
+                            () -> waitingRoom.removeMemberInfo(Set.of(email), performanceId));
 
-            //then
+            // then
             assertThat(exception).doesNotThrowAnyException();
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/waiting/MemoryWaitingRoomTest.java
@@ -1,9 +1,11 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -180,6 +182,43 @@ class MemoryWaitingRoomTest {
 
             // then
             assertThat(room.get(performanceId)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("대기방 사용자 정보 목록 제거 호출 시")
+    class RemoveMemberInfos {
+
+        @Test
+        @DisplayName("사용자 정보가 제거된다.")
+        void removeMemberInfo() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            String email2 = "email2@email.com";
+            waitingRoom.enter(email, performanceId);
+            waitingRoom.enter(email2, performanceId);
+
+            //when
+            waitingRoom.removeMemberInfo(Set.of(email, email2), performanceId);
+
+            //then
+            assertThat(waitingRoom.findWaitingMember(email, performanceId)).isEmpty();
+            assertThat(waitingRoom.findWaitingMember(email2, performanceId)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("사용자 정보가 대기방에 존재하지 않으면 무시한다.")
+        void ignore_WhenNotExistsWaitingRoom() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+
+            //when
+            Exception exception = catchException(() -> waitingRoom.removeMemberInfo(Set.of(email), performanceId));
+
+            //then
+            assertThat(exception).doesNotThrowAnyException();
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
@@ -3,13 +3,10 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 
 @SpringBootTest
 class RedisWaitingRoomTest extends TestContainerStarter {
@@ -215,17 +217,17 @@ class RedisWaitingRoomTest extends TestContainerStarter {
         @Test
         @DisplayName("사용자 정보가 제거된다.")
         void removeMemberInfo() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             String email2 = "email2@email.com";
             waitingRoom.enter(email, performanceId);
             waitingRoom.enter(email2, performanceId);
 
-            //when
+            // when
             waitingRoom.removeMemberInfo(Set.of(email, email2), performanceId);
 
-            //then
+            // then
             assertThat(waitingRoom.findWaitingMember(email, performanceId)).isEmpty();
             assertThat(waitingRoom.findWaitingMember(email2, performanceId)).isEmpty();
         }
@@ -233,14 +235,16 @@ class RedisWaitingRoomTest extends TestContainerStarter {
         @Test
         @DisplayName("사용자 정보가 대기방에 존재하지 않으면 무시한다.")
         void ignore_WhenNotExistsWaitingRoom() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
 
-            //when
-            Exception exception = catchException(() -> waitingRoom.removeMemberInfo(Set.of(email), performanceId));
+            // when
+            Exception exception =
+                    catchException(
+                            () -> waitingRoom.removeMemberInfo(Set.of(email), performanceId));
 
-            //then
+            // then
             assertThat(exception).doesNotThrowAnyException();
         }
     }


### PR DESCRIPTION
### ⛏ 작업 사항
- 러닝룸의 만료된 사용자 정보를 제거할 때, 웨이팅룸의 사용자 정보를 제거하지 않는 문제를 수정했습니다.
- 러닝룸의 만료된 사용자 정보 삭제시 삭제된 사용자 목록을 반환합니다. 이를 이용하여 웨이팅룸의 사용자를 삭제합니다.

### 📝 작업 요약
- 만료된 대기방 사용자를 삭제하지 않는 문제 수정

### 💡 관련 이슈
- close #140
