### PR TITLE
Refactor: 테스트 컨텍스트를 개선한다.

### DIFF
--- a/src/test/java/com/thirdparty/ticketing/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/controller/AuthControllerTest.java
@@ -8,14 +8,15 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.member.dto.request.LoginRequest;
-import com.thirdparty.ticketing.domain.member.dto.response.LoginResponse;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.thirdparty.ticketing.domain.member.dto.request.LoginRequest;
+import com.thirdparty.ticketing.domain.member.dto.response.LoginResponse;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 
 class AuthControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/controller/AuthControllerTest.java
@@ -8,23 +8,16 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.thirdparty.ticketing.domain.member.dto.request.LoginRequest;
+import com.thirdparty.ticketing.domain.member.dto.response.LoginResponse;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.thirdparty.ticketing.domain.member.dto.request.LoginRequest;
-import com.thirdparty.ticketing.domain.member.dto.response.LoginResponse;
-import com.thirdparty.ticketing.domain.member.service.AuthService;
-import com.thirdparty.ticketing.support.BaseControllerTest;
-
-@WebMvcTest(controllers = AuthController.class)
 class AuthControllerTest extends BaseControllerTest {
-
-    @MockBean private AuthService authService;
 
     @Test
     @DisplayName("로그인 API 호출 시")

--- a/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
@@ -8,27 +8,16 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.thirdparty.ticketing.domain.member.dto.request.MemberCreationRequest;
+import com.thirdparty.ticketing.domain.member.dto.response.CreateMemberResponse;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.member.dto.request.MemberCreationRequest;
-import com.thirdparty.ticketing.domain.member.dto.response.CreateMemberResponse;
-import com.thirdparty.ticketing.domain.member.service.MemberService;
-import com.thirdparty.ticketing.support.BaseControllerTest;
-
-@WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest extends BaseControllerTest {
-
-    @Autowired private ObjectMapper objectMapper;
-
-    @MockBean private MemberService memberService;
 
     @Test
     @DisplayName("회원 생성 API 호출")

--- a/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/member/controller/MemberControllerTest.java
@@ -8,14 +8,15 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.member.dto.request.MemberCreationRequest;
-import com.thirdparty.ticketing.domain.member.dto.response.CreateMemberResponse;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.thirdparty.ticketing.domain.member.dto.request.MemberCreationRequest;
+import com.thirdparty.ticketing.domain.member.dto.response.CreateMemberResponse;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 
 class MemberControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/performance/controller/AdminPerformanceControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/performance/controller/AdminPerformanceControllerTest.java
@@ -7,25 +7,17 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.thirdparty.ticketing.domain.performance.dto.request.PerformanceCreationRequest;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.time.ZonedDateTime;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.thirdparty.ticketing.domain.performance.dto.request.PerformanceCreationRequest;
-import com.thirdparty.ticketing.domain.performance.service.AdminPerformanceService;
-import com.thirdparty.ticketing.support.BaseControllerTest;
-
-@WebMvcTest(AdminPerformanceController.class)
 class AdminPerformanceControllerTest extends BaseControllerTest {
-
-    @MockBean private AdminPerformanceService adminPerformanceService;
 
     @Test
     @DisplayName("POST /api/performances")

--- a/src/test/java/com/thirdparty/ticketing/domain/performance/controller/AdminPerformanceControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/performance/controller/AdminPerformanceControllerTest.java
@@ -7,15 +7,17 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.thirdparty.ticketing.domain.performance.dto.request.PerformanceCreationRequest;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.time.ZonedDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.thirdparty.ticketing.domain.performance.dto.request.PerformanceCreationRequest;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 
 class AdminPerformanceControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/performance/controller/UserPerformanceControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/performance/controller/UserPerformanceControllerTest.java
@@ -6,15 +6,17 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.ItemResult;
-import com.thirdparty.ticketing.domain.performance.dto.PerformanceElement;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.time.ZonedDateTime;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.thirdparty.ticketing.domain.ItemResult;
+import com.thirdparty.ticketing.domain.performance.dto.PerformanceElement;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 
 class UserPerformanceControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/performance/controller/UserPerformanceControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/performance/controller/UserPerformanceControllerTest.java
@@ -1,30 +1,22 @@
 package com.thirdparty.ticketing.domain.performance.controller;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.thirdparty.ticketing.domain.ItemResult;
+import com.thirdparty.ticketing.domain.performance.dto.PerformanceElement;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.time.ZonedDateTime;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.thirdparty.ticketing.domain.ItemResult;
-import com.thirdparty.ticketing.domain.performance.dto.PerformanceElement;
-import com.thirdparty.ticketing.domain.performance.service.UserPerformanceService;
-import com.thirdparty.ticketing.support.BaseControllerTest;
-
-@WebMvcTest(UserPerformanceController.class)
 class UserPerformanceControllerTest extends BaseControllerTest {
-
-    @MockBean private UserPerformanceService userPerformanceService;
 
     @Test
     @DisplayName("GET /api/performances")

--- a/src/test/java/com/thirdparty/ticketing/domain/seat/controller/AdminSeatControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/seat/controller/AdminSeatControllerTest.java
@@ -9,18 +9,20 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatCreationElement;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatCreationRequest;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatGradeCreationElement;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatGradeCreationRequest;
 import com.thirdparty.ticketing.support.BaseControllerTest;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.ResultActions;
 
 public class AdminSeatControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/seat/controller/AdminSeatControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/seat/controller/AdminSeatControllerTest.java
@@ -9,28 +9,20 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.ResultActions;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatCreationElement;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatCreationRequest;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatGradeCreationElement;
 import com.thirdparty.ticketing.domain.seat.dto.request.SeatGradeCreationRequest;
-import com.thirdparty.ticketing.domain.seat.service.AdminSeatService;
 import com.thirdparty.ticketing.support.BaseControllerTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(AdminSeatController.class)
 public class AdminSeatControllerTest extends BaseControllerTest {
-
-    @MockBean private AdminSeatService adminSeatService;
 
     @Test
     @DisplayName("관리자 좌석 생성 API")

--- a/src/test/java/com/thirdparty/ticketing/domain/seat/controller/SeatControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/seat/controller/SeatControllerTest.java
@@ -11,27 +11,19 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.ResultActions;
-
 import com.thirdparty.ticketing.domain.ItemResult;
 import com.thirdparty.ticketing.domain.seat.dto.response.SeatElement;
 import com.thirdparty.ticketing.domain.seat.dto.response.SeatGradeElement;
-import com.thirdparty.ticketing.domain.seat.service.SeatService;
 import com.thirdparty.ticketing.support.BaseControllerTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(SeatController.class)
 public class SeatControllerTest extends BaseControllerTest {
 
     public static final String PERFORMANCE_ID = "performanceId";
-
-    @MockBean private SeatService seatService;
 
     @Test
     @DisplayName("구역의 좌석 목록을 조회한다.")

--- a/src/test/java/com/thirdparty/ticketing/domain/seat/controller/SeatControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/seat/controller/SeatControllerTest.java
@@ -11,15 +11,17 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.ItemResult;
-import com.thirdparty.ticketing.domain.seat.dto.response.SeatElement;
-import com.thirdparty.ticketing.domain.seat.dto.response.SeatGradeElement;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.thirdparty.ticketing.domain.ItemResult;
+import com.thirdparty.ticketing.domain.seat.dto.response.SeatElement;
+import com.thirdparty.ticketing.domain.seat.dto.response.SeatGradeElement;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 
 public class SeatControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/ticket/controller/TicketControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/ticket/controller/TicketControllerTest.java
@@ -11,18 +11,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.UUID;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.ResultActions;
-
 import com.thirdparty.ticketing.domain.ItemResult;
 import com.thirdparty.ticketing.domain.performance.dto.PerformanceElement;
 import com.thirdparty.ticketing.domain.seat.dto.response.SeatGradeElement;
@@ -30,17 +18,19 @@ import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
 import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
 import com.thirdparty.ticketing.domain.ticket.dto.response.TicketElement;
 import com.thirdparty.ticketing.domain.ticket.dto.response.TicketSeatDetail;
-import com.thirdparty.ticketing.domain.ticket.service.ReservationService;
-import com.thirdparty.ticketing.domain.ticket.service.TicketService;
 import com.thirdparty.ticketing.support.BaseControllerTest;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(controllers = TicketController.class)
 class TicketControllerTest extends BaseControllerTest {
 
     public static final String PERFORMANCE_ID = "performanceId";
-    @MockBean private TicketService ticketService;
-
-    @MockBean private ReservationService reservationService;
 
     @Test
     @DisplayName("티켓 조회 API 호출 시")

--- a/src/test/java/com/thirdparty/ticketing/domain/ticket/controller/TicketControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/ticket/controller/TicketControllerTest.java
@@ -11,6 +11,16 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
 import com.thirdparty.ticketing.domain.ItemResult;
 import com.thirdparty.ticketing.domain.performance.dto.PerformanceElement;
 import com.thirdparty.ticketing.domain.seat.dto.response.SeatGradeElement;
@@ -19,14 +29,6 @@ import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
 import com.thirdparty.ticketing.domain.ticket.dto.response.TicketElement;
 import com.thirdparty.ticketing.domain.ticket.dto.response.TicketSeatDetail;
 import com.thirdparty.ticketing.support.BaseControllerTest;
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.UUID;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.ResultActions;
 
 class TicketControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/ticket/service/CacheReservationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/ticket/service/CacheReservationTest.java
@@ -2,7 +2,6 @@ package com.thirdparty.ticketing.domain.ticket.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -17,7 +16,6 @@ import org.mockito.MockitoAnnotations;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.thirdparty.ticketing.domain.common.LettuceRepository;
 import com.thirdparty.ticketing.domain.common.TicketingException;
@@ -34,7 +32,7 @@ import com.thirdparty.ticketing.domain.seat.repository.SeatRepository;
 import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
 import com.thirdparty.ticketing.domain.zone.Zone;
 import com.thirdparty.ticketing.domain.zone.repository.ZoneRepository;
-import com.thirdparty.ticketing.support.TestContainerStarter;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 public class CacheReservationTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/ticket/service/CacheReservationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/ticket/service/CacheReservationTest.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.domain.ticket.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -35,8 +36,7 @@ import com.thirdparty.ticketing.domain.zone.Zone;
 import com.thirdparty.ticketing.domain.zone.repository.ZoneRepository;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
-@SpringBootTest
-public class CacheReservationTest extends TestContainerStarter {
+public class CacheReservationTest extends BaseIntegrationTest {
 
     @Autowired private SeatRepository seatRepository;
 

--- a/src/test/java/com/thirdparty/ticketing/domain/ticket/service/PersistenceReservationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/ticket/service/PersistenceReservationTest.java
@@ -2,6 +2,10 @@ package com.thirdparty.ticketing.domain.ticket.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
+import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -9,7 +13,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -26,13 +28,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.thirdparty.ticketing.domain.common.TicketingException;
-import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
-import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
-@SpringBootTest
-public class PersistenceReservationTest extends TestContainerStarter {
+public class PersistenceReservationTest extends BaseIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(PersistenceReservationTest.class);
 
     @Autowired

--- a/src/test/java/com/thirdparty/ticketing/domain/ticket/service/PersistenceReservationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/ticket/service/PersistenceReservationTest.java
@@ -2,10 +2,6 @@ package com.thirdparty.ticketing.domain.ticket.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.thirdparty.ticketing.domain.common.TicketingException;
-import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
-import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -13,6 +9,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,6 +24,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
+import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 public class PersistenceReservationTest extends BaseIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(PersistenceReservationTest.class);

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
@@ -4,37 +4,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
+import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingLine;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-import com.thirdparty.ticketing.domain.member.Member;
-import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.domain.member.service.JwtProvider;
-import com.thirdparty.ticketing.domain.waitingsystem.WaitingAspectTest.TestController;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
-import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingLine;
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
-@SpringBootTest
-@AutoConfigureMockMvc
-@Import(TestController.class)
-class WaitingAspectTest extends TestContainerStarter {
+class WaitingAspectTest extends BaseIntegrationTest {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
@@ -47,16 +35,6 @@ class WaitingAspectTest extends TestContainerStarter {
     @Autowired private RedisRunningRoom runningRoom;
 
     @Autowired private RedisWaitingLine waitingLine;
-
-    @RestController
-    static class TestController {
-
-        @Waiting
-        @GetMapping("/api/waiting/test")
-        public ResponseEntity<String> test() {
-            return ResponseEntity.ok("test");
-        }
-    }
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingAspectTest.java
@@ -4,15 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.member.Member;
-import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.domain.member.service.JwtProvider;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
-import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingLine;
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,6 +15,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.global.waitingsystem.redis.running.RedisRunningRoom;
+import com.thirdparty.ticketing.global.waitingsystem.redis.waiting.RedisWaitingLine;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class WaitingAspectTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
@@ -14,8 +14,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingControllerTest.java
@@ -21,12 +21,9 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.thirdparty.ticketing.support.BaseControllerTest;
 
-@WebMvcTest(controllers = WaitingController.class)
 class WaitingControllerTest extends BaseControllerTest {
 
     public static final String PERFORMANCE_ID = "performanceId";
-
-    @MockBean private WaitingSystem waitingSystem;
 
     @Test
     @DisplayName("남은 대기 순번 조회 API 호출 시")

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
@@ -29,8 +30,7 @@ import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.support.SpyEventPublisher;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
-@SpringBootTest
-class WaitingSystemTest extends TestContainerStarter {
+class WaitingSystemTest extends BaseIntegrationTest {
 
     private WaitingSystem waitingSystem;
 

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -27,8 +25,8 @@ import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.waitingsystem.running.RunningManager;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingManager;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import com.thirdparty.ticketing.support.SpyEventPublisher;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 
 class WaitingSystemTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/zone/controller/AdminZoneControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/zone/controller/AdminZoneControllerTest.java
@@ -9,16 +9,18 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationElement;
-import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationRequest;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationElement;
+import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationRequest;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 
 public class AdminZoneControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/zone/controller/AdminZoneControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/zone/controller/AdminZoneControllerTest.java
@@ -9,27 +9,18 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationElement;
+import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationRequest;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.thirdparty.ticketing.domain.zone.contoller.AdminZoneController;
-import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationElement;
-import com.thirdparty.ticketing.domain.zone.dto.ZoneCreationRequest;
-import com.thirdparty.ticketing.domain.zone.service.AdminZoneService;
-import com.thirdparty.ticketing.support.BaseControllerTest;
-
-@WebMvcTest(AdminZoneController.class)
 public class AdminZoneControllerTest extends BaseControllerTest {
-
-    @MockBean private AdminZoneService adminZoneService;
 
     @Test
     @DisplayName("POST /api/performances/{performanceId}/zones")

--- a/src/test/java/com/thirdparty/ticketing/domain/zone/controller/UserZoneControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/zone/controller/UserZoneControllerTest.java
@@ -10,13 +10,15 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.ItemResult;
-import com.thirdparty.ticketing.domain.zone.dto.ZoneElement;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.thirdparty.ticketing.domain.ItemResult;
+import com.thirdparty.ticketing.domain.zone.dto.ZoneElement;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 
 class UserZoneControllerTest extends BaseControllerTest {
 

--- a/src/test/java/com/thirdparty/ticketing/domain/zone/controller/UserZoneControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/zone/controller/UserZoneControllerTest.java
@@ -1,31 +1,24 @@
 package com.thirdparty.ticketing.domain.zone.controller;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.ResultActions;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.thirdparty.ticketing.domain.ItemResult;
-import com.thirdparty.ticketing.domain.zone.contoller.UserZoneController;
 import com.thirdparty.ticketing.domain.zone.dto.ZoneElement;
-import com.thirdparty.ticketing.domain.zone.service.UserZoneService;
 import com.thirdparty.ticketing.support.BaseControllerTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(UserZoneController.class)
 class UserZoneControllerTest extends BaseControllerTest {
-
-    @MockBean private UserZoneService userZoneService;
 
     @Test
     @DisplayName("GET /api/performances/{performanceId}/zones")

--- a/src/test/java/com/thirdparty/ticketing/global/config/ProductionRedisConfigTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/config/ProductionRedisConfigTest.java
@@ -2,16 +2,14 @@ package com.thirdparty.ticketing.global.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
+import com.thirdparty.ticketing.support.TestContainerStarter;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
-@SpringBootTest
-class ProductionRedisConfigTest extends TestContainerStarter {
+class ProductionRedisConfigTest extends BaseIntegrationTest {
 
     @Autowired private RedissonClient redissonClient;
 

--- a/src/test/java/com/thirdparty/ticketing/global/config/ProductionRedisConfigTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/config/ProductionRedisConfigTest.java
@@ -2,12 +2,12 @@ package com.thirdparty.ticketing.global.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
-import com.thirdparty.ticketing.support.TestContainerStarter;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class ProductionRedisConfigTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
@@ -3,35 +3,19 @@ package com.thirdparty.ticketing.global.security;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-import com.thirdparty.ticketing.domain.common.LoginMember;
-import com.thirdparty.ticketing.domain.member.Member;
-import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.global.security.LoginMemberArgumentResolverTest.ResolverTestController;
-import com.thirdparty.ticketing.support.BaseControllerTest;
-
-@WebMvcTest(controllers = ResolverTestController.class)
 class LoginMemberArgumentResolverTest extends BaseControllerTest {
 
-    @RestController
-    @RequestMapping("/api/test/resolver")
-    public static class ResolverTestController {
 
-        @GetMapping
-        public String resolve(@LoginMember String email) {
-            return email;
-        }
-    }
 
     @Nested
     @DisplayName("핸들러 메서드 파라미터에 @LoginMember가 포함되어 있으면")

--- a/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/security/LoginMemberArgumentResolverTest.java
@@ -3,9 +3,6 @@ package com.thirdparty.ticketing.global.security;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.domain.member.Member;
-import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.support.BaseControllerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,9 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.support.BaseControllerTest;
+
 class LoginMemberArgumentResolverTest extends BaseControllerTest {
-
-
 
     @Nested
     @DisplayName("핸들러 메서드 파라미터에 @LoginMember가 포함되어 있으면")

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
@@ -2,7 +2,6 @@ package com.thirdparty.ticketing.global.waitingsystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -10,13 +9,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
 import com.thirdparty.ticketing.domain.common.EventPublisher;
 import com.thirdparty.ticketing.domain.waitingsystem.WaitingSystem;
-import com.thirdparty.ticketing.support.TestContainerStarter;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class WaitingEventListenerTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.global.waitingsystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,8 +18,7 @@ import com.thirdparty.ticketing.domain.common.EventPublisher;
 import com.thirdparty.ticketing.domain.waitingsystem.WaitingSystem;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
-@SpringBootTest
-class WaitingEventListenerTest extends TestContainerStarter {
+class WaitingEventListenerTest extends BaseIntegrationTest {
 
     @Autowired private WaitingSystem waitingSystem;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspectTest.java
@@ -2,13 +2,13 @@ package com.thirdparty.ticketing.global.waitingsystem.memory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -21,8 +21,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
 
 @ExtendWith(SpringExtension.class)
 @Import(MemoryDebounceAspectTest.MemoryDebounceAopConfig.class)

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/MemoryDebounceAspectTest.java
@@ -2,13 +2,13 @@ package com.thirdparty.ticketing.global.waitingsystem.memory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +21,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
 
 @ExtendWith(SpringExtension.class)
 @Import(MemoryDebounceAspectTest.MemoryDebounceAopConfig.class)

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/DebounceAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/DebounceAspectTest.java
@@ -2,20 +2,21 @@ package com.thirdparty.ticketing.global.waitingsystem.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
-import com.thirdparty.ticketing.support.integration.AspectTestConfig.DebounceTarget;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
+import com.thirdparty.ticketing.support.integration.AspectTestConfig.DebounceTarget;
+
 class DebounceAspectTest extends BaseIntegrationTest {
 
-    @Autowired
-    private DebounceTarget debounceTarget;
+    @Autowired private DebounceTarget debounceTarget;
 
     @Nested
     @DisplayName("디바운스 aop 적용 시")

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/DebounceAspectTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/DebounceAspectTest.java
@@ -2,56 +2,20 @@ package com.thirdparty.ticketing.global.waitingsystem.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
+import com.thirdparty.ticketing.support.integration.AspectTestConfig.DebounceTarget;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 
-import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
-import com.thirdparty.ticketing.global.waitingsystem.redis.DebounceAspectTest.TestConfig;
-import com.thirdparty.ticketing.support.TestContainerStarter;
+class DebounceAspectTest extends BaseIntegrationTest {
 
-@SpringBootTest
-@Import(TestConfig.class)
-class DebounceAspectTest extends TestContainerStarter {
-
-    @Autowired private DebounceTarget debounceTarget;
-
-    @TestConfiguration
-    static class TestConfig {
-
-        @Bean
-        public DebounceTarget debounceTarget() {
-            return new DebounceTarget();
-        }
-    }
-
-    static class DebounceTarget {
-
-        private final AtomicInteger counter;
-
-        public DebounceTarget() {
-            counter = new AtomicInteger(0);
-        }
-
-        @Debounce
-        public void increment() {
-            counter.incrementAndGet();
-        }
-
-        public int get() {
-            return counter.get();
-        }
-    }
+    @Autowired
+    private DebounceTarget debounceTarget;
 
     @Nested
     @DisplayName("디바운스 aop 적용 시")

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
@@ -2,7 +2,6 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -14,11 +13,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-import com.thirdparty.ticketing.support.TestContainerStarter;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class RedisRunningCounterTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningCounterTest.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -19,8 +20,7 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
-@SpringBootTest
-class RedisRunningCounterTest extends TestContainerStarter {
+class RedisRunningCounterTest extends BaseIntegrationTest {
 
     @Autowired private RedisRunningCounter runningCounter;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -19,8 +20,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
-@SpringBootTest
-class RedisRunningManagerTest extends TestContainerStarter {
+class RedisRunningManagerTest extends BaseIntegrationTest {
 
     @Autowired private RedisRunningManager runningManager;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManagerTest.java
@@ -2,7 +2,6 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -12,13 +11,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.ZSetOperations;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.TestContainerStarter;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class RedisRunningManagerTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -2,11 +2,12 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,15 +15,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
-@SpringBootTest
-class RedisRunningRoomTest extends TestContainerStarter {
+class RedisRunningRoomTest extends BaseIntegrationTest {
 
     @Autowired private RedisRunningRoom runningRoom;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -2,12 +2,11 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +16,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
+
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class RedisRunningRoomTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingCounterTest.java
@@ -2,22 +2,18 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
-@SpringBootTest
-class RedisWaitingCounterTest extends TestContainerStarter {
+class RedisWaitingCounterTest extends BaseIntegrationTest {
 
     @Autowired private RedisWaitingCounter waitingCounter;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingCounterTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingCounterTest.java
@@ -2,16 +2,18 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class RedisWaitingCounterTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
@@ -2,27 +2,23 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.TestContainerStarter;
-
-@SpringBootTest
-class RedisWaitingLineTest extends TestContainerStarter {
+class RedisWaitingLineTest extends BaseIntegrationTest {
 
     private static final String WAITING_LINE_KEY = "waiting_line:";
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingLineTest.java
@@ -2,14 +2,11 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class RedisWaitingLineTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
@@ -3,7 +3,6 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -26,7 +24,7 @@ import com.thirdparty.ticketing.domain.common.ErrorCode;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
-import com.thirdparty.ticketing.support.TestContainerStarter;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class RedisWaitingManagerTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingManagerTest.java
@@ -3,6 +3,7 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -27,8 +28,7 @@ import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
-@SpringBootTest
-class RedisWaitingManagerTest extends TestContainerStarter {
+class RedisWaitingManagerTest extends BaseIntegrationTest {
 
     @Autowired private RedisWaitingManager waitingManager;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
@@ -3,6 +3,7 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
@@ -21,8 +22,7 @@ import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
 import com.thirdparty.ticketing.support.TestContainerStarter;
 
-@SpringBootTest
-class RedisWaitingRoomTest extends TestContainerStarter {
+class RedisWaitingRoomTest extends BaseIntegrationTest {
 
     @Autowired private RedisWaitingRoom waitingRoom;
 

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/waiting/RedisWaitingRoomTest.java
@@ -3,7 +3,6 @@ package com.thirdparty.ticketing.global.waitingsystem.redis.waiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
@@ -13,14 +12,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.global.waitingsystem.ObjectMapperUtils;
-import com.thirdparty.ticketing.support.TestContainerStarter;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
 
 class RedisWaitingRoomTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/thirdparty/ticketing/support/BaseControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/BaseControllerTest.java
@@ -6,10 +6,32 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.MemberRole;
+import com.thirdparty.ticketing.domain.member.service.AuthService;
+import com.thirdparty.ticketing.domain.member.service.JwtProvider;
+import com.thirdparty.ticketing.domain.member.service.MemberService;
+import com.thirdparty.ticketing.domain.performance.service.AdminPerformanceService;
+import com.thirdparty.ticketing.domain.performance.service.UserPerformanceService;
+import com.thirdparty.ticketing.domain.seat.service.AdminSeatService;
+import com.thirdparty.ticketing.domain.seat.service.SeatService;
+import com.thirdparty.ticketing.domain.ticket.service.ReservationService;
+import com.thirdparty.ticketing.domain.ticket.service.TicketService;
+import com.thirdparty.ticketing.domain.waitingsystem.WaitingSystem;
+import com.thirdparty.ticketing.domain.zone.service.AdminZoneService;
+import com.thirdparty.ticketing.domain.zone.service.UserZoneService;
+import com.thirdparty.ticketing.global.config.SecurityConfig;
+import com.thirdparty.ticketing.global.config.WebConfig;
+import com.thirdparty.ticketing.support.BaseControllerTest.RestDocsConfig;
+import com.thirdparty.ticketing.support.controller.DocsController;
+import com.thirdparty.ticketing.support.controller.ResolverTestController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -21,15 +43,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thirdparty.ticketing.domain.member.Member;
-import com.thirdparty.ticketing.domain.member.MemberRole;
-import com.thirdparty.ticketing.domain.member.service.JwtProvider;
-import com.thirdparty.ticketing.global.config.SecurityConfig;
-import com.thirdparty.ticketing.global.config.WebConfig;
-import com.thirdparty.ticketing.support.BaseControllerTest.RestDocsConfig;
-
-@Import({RestDocsConfig.class, SecurityConfig.class, WebConfig.class})
+@WebMvcTest
+@Import({RestDocsConfig.class, SecurityConfig.class, WebConfig.class, DocsController.class, ResolverTestController.class})
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class BaseControllerTest {
 
@@ -39,13 +54,46 @@ public abstract class BaseControllerTest {
 
     @Autowired protected ObjectMapper objectMapper;
 
+    @Autowired protected RestDocumentationResultHandler restDocs;
+
+    @MockBean
+    protected MemberService memberService;
+
+    @MockBean
+    protected TicketService ticketService;
+
+    @MockBean
+    protected AdminPerformanceService adminPerformanceService;
+
+    @MockBean
+    protected UserPerformanceService userPerformanceService;
+
+    @MockBean
+    protected AdminSeatService adminSeatService;
+
+    @MockBean
+    protected SeatService seatService;
+
+    @MockBean
+    protected AdminZoneService adminZoneService;
+
+    @MockBean
+    protected UserZoneService userZoneService;
+
+    @MockBean
+    protected ReservationService reservationService;
+
+    @MockBean
+    protected AuthService authService;
+
+    @MockBean
+    protected WaitingSystem waitingSystem;
+
     protected String adminBearerToken;
 
     protected String userBearerToken;
 
     protected MockMvc mockMvc;
-
-    @Autowired protected RestDocumentationResultHandler restDocs;
 
     @TestConfiguration
     public static class RestDocsConfig {

--- a/src/test/java/com/thirdparty/ticketing/support/BaseControllerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/BaseControllerTest.java
@@ -6,6 +6,23 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thirdparty.ticketing.domain.member.Member;
 import com.thirdparty.ticketing.domain.member.MemberRole;
@@ -26,25 +43,15 @@ import com.thirdparty.ticketing.global.config.WebConfig;
 import com.thirdparty.ticketing.support.BaseControllerTest.RestDocsConfig;
 import com.thirdparty.ticketing.support.controller.DocsController;
 import com.thirdparty.ticketing.support.controller.ResolverTestController;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 @WebMvcTest
-@Import({RestDocsConfig.class, SecurityConfig.class, WebConfig.class, DocsController.class, ResolverTestController.class})
+@Import({
+    RestDocsConfig.class,
+    SecurityConfig.class,
+    WebConfig.class,
+    DocsController.class,
+    ResolverTestController.class
+})
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class BaseControllerTest {
 
@@ -56,38 +63,27 @@ public abstract class BaseControllerTest {
 
     @Autowired protected RestDocumentationResultHandler restDocs;
 
-    @MockBean
-    protected MemberService memberService;
+    @MockBean protected MemberService memberService;
 
-    @MockBean
-    protected TicketService ticketService;
+    @MockBean protected TicketService ticketService;
 
-    @MockBean
-    protected AdminPerformanceService adminPerformanceService;
+    @MockBean protected AdminPerformanceService adminPerformanceService;
 
-    @MockBean
-    protected UserPerformanceService userPerformanceService;
+    @MockBean protected UserPerformanceService userPerformanceService;
 
-    @MockBean
-    protected AdminSeatService adminSeatService;
+    @MockBean protected AdminSeatService adminSeatService;
 
-    @MockBean
-    protected SeatService seatService;
+    @MockBean protected SeatService seatService;
 
-    @MockBean
-    protected AdminZoneService adminZoneService;
+    @MockBean protected AdminZoneService adminZoneService;
 
-    @MockBean
-    protected UserZoneService userZoneService;
+    @MockBean protected UserZoneService userZoneService;
 
-    @MockBean
-    protected ReservationService reservationService;
+    @MockBean protected ReservationService reservationService;
 
-    @MockBean
-    protected AuthService authService;
+    @MockBean protected AuthService authService;
 
-    @MockBean
-    protected WaitingSystem waitingSystem;
+    @MockBean protected WaitingSystem waitingSystem;
 
     protected String adminBearerToken;
 

--- a/src/test/java/com/thirdparty/ticketing/support/BaseIntegrationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/BaseIntegrationTest.java
@@ -1,0 +1,25 @@
+package com.thirdparty.ticketing.support;
+
+import com.thirdparty.ticketing.support.integration.AspectTestConfig;
+import com.thirdparty.ticketing.support.integration.AspectTestConfig.DebounceTarget;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(AspectTestConfig.class)
+public class BaseIntegrationTest extends TestContainerStarter {
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public DebounceTarget debounceTarget() {
+            return new DebounceTarget();
+        }
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/support/BaseIntegrationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/BaseIntegrationTest.java
@@ -1,13 +1,13 @@
 package com.thirdparty.ticketing.support;
 
-import com.thirdparty.ticketing.support.integration.AspectTestConfig;
-import com.thirdparty.ticketing.support.integration.AspectTestConfig.DebounceTarget;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
+import com.thirdparty.ticketing.support.integration.AspectTestConfig;
+import com.thirdparty.ticketing.support.integration.AspectTestConfig.DebounceTarget;
 
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/com/thirdparty/ticketing/support/controller/DocsController.java
+++ b/src/test/java/com/thirdparty/ticketing/support/controller/DocsController.java
@@ -1,0 +1,35 @@
+package com.thirdparty.ticketing.support.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test/docs")
+public class DocsController {
+
+    public record HelloRequest(String name) {}
+
+    @GetMapping("/hello")
+    public ResponseEntity<Map<String, String>> hello(@RequestParam("name") String name) {
+        Map<String, String> map = new HashMap<>();
+        map.put("hello", name);
+        return ResponseEntity.ok(map);
+    }
+
+    @PostMapping("/hello/{test}")
+    public ResponseEntity<Map<String, String>> hello2(
+            @PathVariable("test") Long testVariable, @RequestBody HelloRequest request) {
+        Map<String, String> map = new HashMap<>();
+        map.put("hello", request.name);
+        map.put("pathVariable", testVariable.toString());
+        return ResponseEntity.ok(map);
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/support/controller/DocsController.java
+++ b/src/test/java/com/thirdparty/ticketing/support/controller/DocsController.java
@@ -2,6 +2,7 @@ package com.thirdparty.ticketing.support.controller;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/test/java/com/thirdparty/ticketing/support/controller/DocumentationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/controller/DocumentationTest.java
@@ -1,4 +1,4 @@
-package com.thirdparty.ticketing.support;
+package com.thirdparty.ticketing.support.controller;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -10,54 +10,16 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import com.thirdparty.ticketing.support.BaseControllerTest;
+import com.thirdparty.ticketing.support.controller.DocsController.HelloRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
-import com.thirdparty.ticketing.support.DocumentationTest.DocsController;
-
-@WebMvcTest(controllers = DocumentationTest.class)
-@Import(DocsController.class)
 @DisplayName("API 문서 테스트 코드 작성 시")
 public class DocumentationTest extends BaseControllerTest {
-
-    public record HelloRequest(String name) {}
-
-    @RestController
-    @RequestMapping("/test/docs")
-    public static class DocsController {
-
-        @GetMapping("/hello")
-        public ResponseEntity<Map<String, String>> hello(@RequestParam("name") String name) {
-            Map<String, String> map = new HashMap<>();
-            map.put("hello", name);
-            return ResponseEntity.ok(map);
-        }
-
-        @PostMapping("/hello/{test}")
-        public ResponseEntity<Map<String, String>> hello2(
-                @PathVariable("test") Long testVariable, @RequestBody HelloRequest request) {
-            Map<String, String> map = new HashMap<>();
-            map.put("hello", request.name);
-            map.put("pathVariable", testVariable.toString());
-            return ResponseEntity.ok(map);
-        }
-    }
 
     @Test
     @DisplayName("GET 요청을 다음과 같이 문서화 할 수 있다.")

--- a/src/test/java/com/thirdparty/ticketing/support/controller/DocumentationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/support/controller/DocumentationTest.java
@@ -10,13 +10,14 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.thirdparty.ticketing.support.BaseControllerTest;
-import com.thirdparty.ticketing.support.controller.DocsController.HelloRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.thirdparty.ticketing.support.BaseControllerTest;
+import com.thirdparty.ticketing.support.controller.DocsController.HelloRequest;
 
 @DisplayName("API 문서 테스트 코드 작성 시")
 public class DocumentationTest extends BaseControllerTest {

--- a/src/test/java/com/thirdparty/ticketing/support/controller/ResolverTestController.java
+++ b/src/test/java/com/thirdparty/ticketing/support/controller/ResolverTestController.java
@@ -1,9 +1,10 @@
 package com.thirdparty.ticketing.support.controller;
 
-import com.thirdparty.ticketing.domain.common.LoginMember;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.thirdparty.ticketing.domain.common.LoginMember;
 
 @RestController
 @RequestMapping("/api/test/resolver")

--- a/src/test/java/com/thirdparty/ticketing/support/controller/ResolverTestController.java
+++ b/src/test/java/com/thirdparty/ticketing/support/controller/ResolverTestController.java
@@ -1,0 +1,16 @@
+package com.thirdparty.ticketing.support.controller;
+
+import com.thirdparty.ticketing.domain.common.LoginMember;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/test/resolver")
+public class ResolverTestController {
+
+    @GetMapping
+    public String resolve(@LoginMember String email) {
+        return email;
+    }
+}

--- a/src/test/java/com/thirdparty/ticketing/support/integration/AspectTestConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/support/integration/AspectTestConfig.java
@@ -1,13 +1,15 @@
 package com.thirdparty.ticketing.support.integration;
 
-import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
-import com.thirdparty.ticketing.domain.waitingsystem.Waiting;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
+import com.thirdparty.ticketing.domain.waitingsystem.Waiting;
 
 @TestConfiguration
 public class AspectTestConfig {

--- a/src/test/java/com/thirdparty/ticketing/support/integration/AspectTestConfig.java
+++ b/src/test/java/com/thirdparty/ticketing/support/integration/AspectTestConfig.java
@@ -1,0 +1,47 @@
+package com.thirdparty.ticketing.support.integration;
+
+import com.thirdparty.ticketing.domain.waitingsystem.Debounce;
+import com.thirdparty.ticketing.domain.waitingsystem.Waiting;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@TestConfiguration
+public class AspectTestConfig {
+
+    @Bean
+    public DebounceTarget debounceTarget() {
+        return new DebounceTarget();
+    }
+
+    public static class DebounceTarget {
+
+        private final AtomicInteger counter;
+
+        public DebounceTarget() {
+            counter = new AtomicInteger(0);
+        }
+
+        @Debounce
+        public void increment() {
+            counter.incrementAndGet();
+        }
+
+        public int get() {
+            return counter.get();
+        }
+    }
+
+    @RestController
+    static class TestController {
+
+        @Waiting
+        @GetMapping("/api/waiting/test")
+        public ResponseEntity<String> test() {
+            return ResponseEntity.ok("test");
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 표현 계층 테스트 컨텍스트를 통일하였습니다.
  - 모든 목 빈 생성, config 클래스 임포트를 `BaseControllerTest`로 올리고 표현 계층 테스트는 해당 클래스를 상속합니다.
- 통합 테스트 컨텍스트를 통일하였습니다.
  - `@SpringBootTest`를 사용하는 모든 테스트와 config 클래스를 `BaseIntegrationTest`로 올리고 통합 테스트는 해당 클래스를 상속합니다.
- 42초에서 31~34초 수준으로 테스트 수행시간이 감소하였습니다.
- 초기화되는 컨텍스트 수는 19개에서 5개로 감소하였습니다. 

### 📝 작업 요약
- 테스트 컨텍스트 빈 구성 통일

### 💡 관련 이슈
- close #147 
