### PR TITLE
Feature: redis 캐시 정책을 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,6 @@ tasks.register('copyYml') {
 }
 
 build {
-    dependsOn copyDocument
+    mustRunAfter copyDocument
     dependsOn copyYml
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/RedisSeat.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/RedisSeat.java
@@ -59,4 +59,13 @@ public class RedisSeat {
     public void markAsSelected() {
         this.seatStatus = SeatStatus.SELECTED;
     }
+
+    public void releaseSeat(Member loginMember) {
+        if (!isAssignedByMember(loginMember)) {
+            throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
+        }
+
+        this.memberId = null;
+        this.seatStatus = SeatStatus.SELECTABLE;
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/RedisSeat.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/RedisSeat.java
@@ -1,0 +1,62 @@
+package com.thirdparty.ticketing.domain.seat;
+
+import org.springframework.data.redis.core.RedisHash;
+
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.member.Member;
+
+import lombok.Getter;
+
+@RedisHash("seat-data")
+@Getter
+public class RedisSeat {
+
+    private Long seatId;
+    private Long memberId; // 예약한 유저 정보 -> null이면 아직 없음
+    private SeatStatus seatStatus; // 예약 상태 -> 예약 가능, 예약 불가능
+
+    public RedisSeat(Long seatId, Long memberId, SeatStatus seatStatus) {
+        this.seatId = seatId;
+        this.memberId = memberId;
+        this.seatStatus = seatStatus;
+    }
+
+    public void checkValid() {
+        if (this.seatStatus != SeatStatus.SELECTED) {
+            throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
+        }
+    }
+
+    public void assignByMember(Member member) {
+        if (this.seatStatus != SeatStatus.SELECTABLE) {
+            throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
+        }
+
+        this.memberId = member.getMemberId();
+        this.seatStatus = SeatStatus.SELECTED;
+    }
+
+    public boolean isAssignedByMember(Member loginMember) {
+        return loginMember.getMemberId().equals(this.memberId)
+                && this.seatStatus == SeatStatus.SELECTED;
+    }
+
+    public void markAsPendingPayment() {
+        if (!seatStatus.isSelected()) {
+            throw new TicketingException(ErrorCode.INVALID_SEAT_STATUS);
+        }
+        this.seatStatus = SeatStatus.PENDING_PAYMENT;
+    }
+
+    public void markAsPaid() {
+        if (!seatStatus.isPendingPayment()) {
+            throw new TicketingException(ErrorCode.INVALID_SEAT_STATUS);
+        }
+        this.seatStatus = SeatStatus.PAID;
+    }
+
+    public void markAsSelected() {
+        this.seatStatus = SeatStatus.SELECTED;
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/RedisSeat.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/RedisSeat.java
@@ -1,14 +1,11 @@
 package com.thirdparty.ticketing.domain.seat;
 
-import org.springframework.data.redis.core.RedisHash;
-
 import com.thirdparty.ticketing.domain.common.ErrorCode;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.member.Member;
 
 import lombok.Getter;
 
-@RedisHash("seat-data")
 @Getter
 public class RedisSeat {
 
@@ -22,8 +19,8 @@ public class RedisSeat {
         this.seatStatus = seatStatus;
     }
 
-    public void checkValid() {
-        if (this.seatStatus != SeatStatus.SELECTED) {
+    public void checkSelectable() {
+        if (this.seatStatus != SeatStatus.SELECTABLE) {
             throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
         }
     }

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/Seat.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/Seat.java
@@ -47,7 +47,7 @@ public class Seat extends BaseEntity {
     @Column(length = 16, nullable = false)
     private SeatStatus seatStatus = SeatStatus.SELECTABLE;
 
-    @Version private Long version;
+    private Long version;
 
     public Seat(String seatCode, SeatStatus seatStatus) {
         this.seatCode = seatCode;

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/Seat.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/Seat.java
@@ -47,7 +47,7 @@ public class Seat extends BaseEntity {
     @Column(length = 16, nullable = false)
     private SeatStatus seatStatus = SeatStatus.SELECTABLE;
 
-    private Long version;
+    @Version private Long version;
 
     public Seat(String seatCode, SeatStatus seatStatus) {
         this.seatCode = seatCode;

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/repository/LettuceSeatRepository.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/repository/LettuceSeatRepository.java
@@ -1,0 +1,11 @@
+package com.thirdparty.ticketing.domain.seat.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.thirdparty.ticketing.domain.seat.RedisSeat;
+
+public interface LettuceSeatRepository extends CrudRepository<RedisSeat, Long> {
+    Optional<RedisSeat> findBySeatId(Long seatId);
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/repository/LettuceSeatRepository.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/repository/LettuceSeatRepository.java
@@ -13,7 +13,10 @@ import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.seat.RedisSeat;
 import com.thirdparty.ticketing.domain.seat.SeatStatus;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Repository
+@Slf4j
 public class LettuceSeatRepository {
     private static final String SEAT_DATA_KEY = "seat-data-";
     private final HashOperations<String, String, String> seatData;
@@ -38,6 +41,11 @@ public class LettuceSeatRepository {
                         SeatStatus.valueOf(seatMap.get("seatStatus")));
 
         return Optional.of(redisSeat);
+    }
+
+    public void selectSeat(RedisSeat redisSeat) {
+        update(redisSeat);
+        log.info("Seat {} selected by member {}", redisSeat.getSeatId(), redisSeat.getMemberId());
     }
 
     public void update(RedisSeat redisSeat) {

--- a/src/main/java/com/thirdparty/ticketing/domain/seat/repository/LettuceSeatRepository.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/seat/repository/LettuceSeatRepository.java
@@ -1,11 +1,58 @@
 package com.thirdparty.ticketing.domain.seat.repository;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
 
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.seat.RedisSeat;
+import com.thirdparty.ticketing.domain.seat.SeatStatus;
 
-public interface LettuceSeatRepository extends CrudRepository<RedisSeat, Long> {
-    Optional<RedisSeat> findBySeatId(Long seatId);
+@Repository
+public class LettuceSeatRepository {
+    private static final String SEAT_DATA_KEY = "seat-data-";
+    private final HashOperations<String, String, String> seatData;
+
+    public LettuceSeatRepository(StringRedisTemplate redisTemplate) {
+        this.seatData = redisTemplate.opsForHash();
+    }
+
+    public Optional<RedisSeat> findBySeatId(Long seatId) {
+        Map<String, String> seatMap = seatData.entries(getSeatDataKey(seatId));
+
+        if (seatMap.isEmpty()) {
+            throw new TicketingException(ErrorCode.NOT_FOUND_SEAT);
+        }
+
+        RedisSeat redisSeat =
+                new RedisSeat(
+                        Long.valueOf(seatMap.get("seatId")),
+                        seatMap.get("memberId") != null
+                                ? Long.valueOf(seatMap.get("memberId"))
+                                : null,
+                        SeatStatus.valueOf(seatMap.get("seatStatus")));
+
+        return Optional.of(redisSeat);
+    }
+
+    public void update(RedisSeat redisSeat) {
+        // 값 있는지 체크 안하고 하면 side effect 발생
+        Map<String, String> seatMap = new HashMap<>();
+        seatMap.put("seatId", redisSeat.getSeatId().toString());
+        if (redisSeat.getMemberId() != null) {
+            seatMap.put("memberId", redisSeat.getMemberId().toString());
+        }
+        seatMap.put("seatStatus", redisSeat.getSeatStatus().toString());
+
+        seatData.putAll(getSeatDataKey(redisSeat.getSeatId()), seatMap);
+    }
+
+    private String getSeatDataKey(Long seatId) {
+        return SEAT_DATA_KEY + seatId;
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationManager.java
@@ -1,27 +1,7 @@
 package com.thirdparty.ticketing.domain.ticket.service;
 
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.thirdparty.ticketing.domain.common.ErrorCode;
-import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.member.Member;
-import com.thirdparty.ticketing.domain.seat.Seat;
-import com.thirdparty.ticketing.domain.seat.repository.SeatRepository;
 
-import lombok.RequiredArgsConstructor;
-
-@Component
-@RequiredArgsConstructor
-public class ReservationManager {
-    private final SeatRepository seatRepository;
-
-    @Transactional
-    public void releaseSeat(Member loginMember, long seatId) {
-        Seat seat =
-                seatRepository
-                        .findById(seatId)
-                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
-        seat.releaseSeat(loginMember);
-    }
+public interface ReservationManager {
+    void releaseSeat(Member loginMember, long seatId);
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationManagerTransactionalImpl.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationManagerTransactionalImpl.java
@@ -1,0 +1,27 @@
+package com.thirdparty.ticketing.domain.ticket.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.seat.Seat;
+import com.thirdparty.ticketing.domain.seat.repository.SeatRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationManagerTransactionalImpl implements ReservationManager {
+    private final SeatRepository seatRepository;
+
+    @Transactional
+    public void releaseSeat(Member loginMember, long seatId) {
+        Seat seat =
+                seatRepository
+                        .findById(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+        seat.releaseSeat(loginMember);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
@@ -1,11 +1,7 @@
 package com.thirdparty.ticketing.domain.ticket.service;
 
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.thirdparty.ticketing.domain.common.ErrorCode;
@@ -18,6 +14,7 @@ import com.thirdparty.ticketing.domain.payment.dto.PaymentRequest;
 import com.thirdparty.ticketing.domain.seat.RedisSeat;
 import com.thirdparty.ticketing.domain.seat.Seat;
 import com.thirdparty.ticketing.domain.seat.repository.LettuceSeatRepository;
+import com.thirdparty.ticketing.domain.seat.repository.SeatRepository;
 import com.thirdparty.ticketing.domain.ticket.Ticket;
 import com.thirdparty.ticketing.domain.ticket.dto.event.PaymentEvent;
 import com.thirdparty.ticketing.domain.ticket.dto.event.SeatEvent;
@@ -36,13 +33,8 @@ public class ReservationRedisService implements ReservationService {
     private final EventPublisher eventPublisher;
     private final PaymentProcessor paymentProcessor;
     private final LettuceSeatRepository lettuceSeatRepository;
-    private final ReservationManager reservationManager;
+    private final SeatRepository seatRepository;
     private final TicketRepository ticketRepository;
-
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(5);
-
-    @Value("${ticketing.reservation.release-delay-seconds}")
-    private int reservationReleaseDelay;
 
     @Override
     @Transactional
@@ -61,22 +53,20 @@ public class ReservationRedisService implements ReservationService {
                         .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_MEMBER));
 
         seat.assignByMember(member);
-
-        // 좌석 선택 이벤트 발행
         eventPublisher.publish(new SeatEvent(memberEmail, seatId, SeatEvent.EventType.SELECT));
-
-        scheduler.schedule(
-                () -> reservationManager.releaseSeat(member, seatId),
-                reservationReleaseDelay,
-                TimeUnit.SECONDS);
     }
 
     @Override
     @Transactional
     public void reservationTicket(String memberEmail, TicketPaymentRequest ticketPaymentRequest) {
         Long seatId = ticketPaymentRequest.getSeatId();
-        RedisSeat seat =
+        RedisSeat redisSeat =
                 lettuceSeatRepository
+                        .findById(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+
+        Seat seat =
+                seatRepository
                         .findById(seatId)
                         .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
 
@@ -85,23 +75,27 @@ public class ReservationRedisService implements ReservationService {
                         .findByEmail(memberEmail)
                         .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_MEMBER));
 
-        processPayment(seat, loginMember);
+        processPayment(redisSeat, loginMember);
 
         Ticket ticket =
                 Ticket.builder()
                         .ticketSerialNumber(UUID.randomUUID())
-                        .seat(Seat.builder().seatId(seat.getSeatId()).build())
+                        .seat(Seat.builder().seatId(redisSeat.getSeatId()).build())
                         .member(loginMember)
                         .build();
         try {
+            // 이벤트 기반으로 하는게 제일 이상적이지만... 일단은 이렇게 -> 강제로 정합성을 통일함.
+            redisSeat.markAsPaid();
+            seat.assignByMember(loginMember);
             seat.markAsPaid();
             ticketRepository.save(ticket);
+            seatRepository.save(seat);
         } catch (Exception e) {
             log.error("Failed to save ticket: {}", e.getMessage());
-            seat.markAsSelected();
+            redisSeat.markAsSelected();
             throw new TicketingException(ErrorCode.PAYMENT_FAILED);
         } finally {
-            lettuceSeatRepository.save(seat);
+            lettuceSeatRepository.save(redisSeat);
         }
     }
 

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
@@ -3,6 +3,7 @@ package com.thirdparty.ticketing.domain.ticket.service;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ public class ReservationRedisService implements ReservationService {
     private final EventPublisher eventPublisher;
     private final PaymentProcessor paymentProcessor;
     private final LettuceSeatRepository lettuceSeatRepository;
+    private final ReservationManager reservationManager;
     private final TicketRepository ticketRepository;
 
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(5);
@@ -63,10 +65,10 @@ public class ReservationRedisService implements ReservationService {
         // 좌석 선택 이벤트 발행
         eventPublisher.publish(new SeatEvent(memberEmail, seatId, SeatEvent.EventType.SELECT));
 
-        //        scheduler.schedule(
-        //                () -> reservationManager.releaseSeat(member, seatId),
-        //                reservationReleaseDelay,
-        //                TimeUnit.SECONDS);
+        scheduler.schedule(
+                () -> reservationManager.releaseSeat(member, seatId),
+                reservationReleaseDelay,
+                TimeUnit.SECONDS);
         // 좌석 release는 주석처리
     }
 

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
@@ -1,7 +1,10 @@
 package com.thirdparty.ticketing.domain.ticket.service;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.thirdparty.ticketing.domain.common.ErrorCode;
@@ -35,6 +38,7 @@ public class ReservationRedisService implements ReservationService {
     private final LettuceSeatRepository lettuceSeatRepository;
     private final SeatRepository seatRepository;
     private final TicketRepository ticketRepository;
+    private final StringRedisTemplate redisTemplate;
 
     @Override
     @Transactional
@@ -55,6 +59,9 @@ public class ReservationRedisService implements ReservationService {
         lettuceSeatRepository.selectSeat(redisSeat);
         // event publish
         eventPublisher.publish(new SeatEvent(memberEmail, seatId, SeatEvent.EventType.SELECT));
+        Map<String, String> map = new HashMap<>();
+        map.put("occupy", seatId.toString());
+        redisTemplate.opsForStream().add("seat-stream", map);
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
@@ -1,0 +1,117 @@
+package com.thirdparty.ticketing.domain.ticket.service;
+
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.EventPublisher;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
+import com.thirdparty.ticketing.domain.payment.PaymentProcessor;
+import com.thirdparty.ticketing.domain.payment.dto.PaymentRequest;
+import com.thirdparty.ticketing.domain.seat.RedisSeat;
+import com.thirdparty.ticketing.domain.seat.Seat;
+import com.thirdparty.ticketing.domain.seat.repository.LettuceSeatRepository;
+import com.thirdparty.ticketing.domain.ticket.Ticket;
+import com.thirdparty.ticketing.domain.ticket.dto.event.PaymentEvent;
+import com.thirdparty.ticketing.domain.ticket.dto.event.SeatEvent;
+import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
+import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
+import com.thirdparty.ticketing.domain.ticket.repository.TicketRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ReservationRedisService implements ReservationService {
+
+    private final MemberRepository memberRepository;
+    private final EventPublisher eventPublisher;
+    private final PaymentProcessor paymentProcessor;
+    private final LettuceSeatRepository lettuceSeatRepository;
+    private final TicketRepository ticketRepository;
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(5);
+
+    @Value("${ticketing.reservation.release-delay-seconds}")
+    private int reservationReleaseDelay;
+
+    @Override
+    @Transactional
+    public void selectSeat(String memberEmail, SeatSelectionRequest seatSelectionRequest) {
+        Long seatId = seatSelectionRequest.getSeatId();
+
+        RedisSeat seat =
+                lettuceSeatRepository
+                        .findBySeatId(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+        seat.checkValid(); // 좌석이 선택 가능한지 확인 -> 디비 부하를 줄이기 위해 배치
+
+        Member member =
+                memberRepository
+                        .findByEmail(memberEmail)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_MEMBER));
+
+        seat.assignByMember(member);
+
+        // 좌석 선택 이벤트 발행
+        eventPublisher.publish(new SeatEvent(memberEmail, seatId, SeatEvent.EventType.SELECT));
+
+        //        scheduler.schedule(
+        //                () -> reservationManager.releaseSeat(member, seatId),
+        //                reservationReleaseDelay,
+        //                TimeUnit.SECONDS);
+        // 좌석 release는 주석처리
+    }
+
+    @Override
+    @Transactional
+    public void reservationTicket(String memberEmail, TicketPaymentRequest ticketPaymentRequest) {
+        Long seatId = ticketPaymentRequest.getSeatId();
+        RedisSeat seat =
+                lettuceSeatRepository
+                        .findById(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+
+        Member loginMember =
+                memberRepository
+                        .findByEmail(memberEmail)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_MEMBER));
+
+        processPayment(seat, loginMember);
+
+        Ticket ticket =
+                Ticket.builder()
+                        .ticketSerialNumber(UUID.randomUUID())
+                        .seat(Seat.builder().seatId(seat.getSeatId()).build())
+                        .member(loginMember)
+                        .build();
+
+        lettuceSeatRepository.save(seat);
+        // 나중에 티켓이 저장이 안되었을 때 강제로 저장하는 방법 고민
+        ticketRepository.save(ticket);
+    }
+
+    @Override
+    public void releaseSeat(String memberEmail, SeatSelectionRequest seatSelectionRequest) {
+        // TODO 구현하기 후순위
+    }
+
+    private void processPayment(RedisSeat seat, Member loginMember) {
+        if (!seat.isAssignedByMember(loginMember)) {
+            throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
+        }
+
+        seat.markAsPendingPayment();
+        paymentProcessor.processPayment(new PaymentRequest());
+        seat.markAsPaid();
+        PaymentEvent paymentEvent = new PaymentEvent(loginMember.getEmail());
+        eventPublisher.publish(paymentEvent);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/ReservationRedisService.java
@@ -45,7 +45,6 @@ public class ReservationRedisService implements ReservationService {
                 lettuceSeatRepository
                         .findBySeatId(seatId)
                         .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
-        redisSeat.checkSelectable(); // 좌석이 선택 가능한지 확인 -> 디비 부하를 줄이기 위해 배치
 
         Member member =
                 memberRepository
@@ -53,7 +52,8 @@ public class ReservationRedisService implements ReservationService {
                         .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_MEMBER));
 
         redisSeat.assignByMember(member);
-        lettuceSeatRepository.update(redisSeat);
+        lettuceSeatRepository.selectSeat(redisSeat);
+        // event publish
         eventPublisher.publish(new SeatEvent(memberEmail, seatId, SeatEvent.EventType.SELECT));
     }
 

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/proxy/LettuceReservationServiceProxy.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/proxy/LettuceReservationServiceProxy.java
@@ -1,56 +1,26 @@
 package com.thirdparty.ticketing.domain.ticket.service.proxy;
 
-import com.thirdparty.ticketing.domain.common.ErrorCode;
-import com.thirdparty.ticketing.domain.common.LettuceRepository;
-import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
 import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
 import com.thirdparty.ticketing.domain.ticket.service.ReservationService;
+import com.thirdparty.ticketing.global.lock.lettuce.LettuceLockAnnotation;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class LettuceReservationServiceProxy implements ReservationServiceProxy {
-
-    private final LettuceRepository lettuceRepository;
     private final ReservationService reservationService;
 
-    private void performSeatAction(String seatId, Runnable action) {
-        int retryLimit = 5;
-        int sleepDuration = 300;
-        String lockPrefix = "seat:";
-        String lockKey = lockPrefix + seatId;
-        try {
-            while (retryLimit > 0 && !lettuceRepository.seatLock(lockKey)) {
-                retryLimit -= 1;
-                Thread.sleep(sleepDuration);
-            }
-
-            if (retryLimit > 0) {
-                action.run();
-            } else {
-                throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
-            }
-
-        } catch (InterruptedException e) {
-            throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT, e);
-        } finally {
-            lettuceRepository.unlock(lockKey);
-        }
-    }
-
     @Override
+    @LettuceLockAnnotation(key = "#seatSelectionRequest.seatId")
     public void selectSeat(String memberEmail, SeatSelectionRequest seatSelectionRequest) {
-        performSeatAction(
-                seatSelectionRequest.getSeatId().toString(),
-                () -> reservationService.selectSeat(memberEmail, seatSelectionRequest));
+        reservationService.selectSeat(memberEmail, seatSelectionRequest);
     }
 
     @Override
+    @LettuceLockAnnotation(key = "#ticketPaymentRequest.seatId")
     public void reservationTicket(String memberEmail, TicketPaymentRequest ticketPaymentRequest) {
-        performSeatAction(
-                ticketPaymentRequest.getSeatId().toString(),
-                () -> reservationService.reservationTicket(memberEmail, ticketPaymentRequest));
+        reservationService.reservationTicket(memberEmail, ticketPaymentRequest);
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/proxy/LettuceReservationServiceProxy.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/proxy/LettuceReservationServiceProxy.java
@@ -5,7 +5,7 @@ import com.thirdparty.ticketing.domain.common.LettuceRepository;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
 import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
-import com.thirdparty.ticketing.domain.ticket.service.ReservationTransactionService;
+import com.thirdparty.ticketing.domain.ticket.service.ReservationService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class LettuceReservationServiceProxy implements ReservationServiceProxy {
 
     private final LettuceRepository lettuceRepository;
-    private final ReservationTransactionService reservationTransactionService;
+    private final ReservationService reservationService;
 
     private void performSeatAction(String seatId, Runnable action) {
         int retryLimit = 5;
@@ -43,20 +43,18 @@ public class LettuceReservationServiceProxy implements ReservationServiceProxy {
     public void selectSeat(String memberEmail, SeatSelectionRequest seatSelectionRequest) {
         performSeatAction(
                 seatSelectionRequest.getSeatId().toString(),
-                () -> reservationTransactionService.selectSeat(memberEmail, seatSelectionRequest));
+                () -> reservationService.selectSeat(memberEmail, seatSelectionRequest));
     }
 
     @Override
     public void reservationTicket(String memberEmail, TicketPaymentRequest ticketPaymentRequest) {
         performSeatAction(
                 ticketPaymentRequest.getSeatId().toString(),
-                () ->
-                        reservationTransactionService.reservationTicket(
-                                memberEmail, ticketPaymentRequest));
+                () -> reservationService.reservationTicket(memberEmail, ticketPaymentRequest));
     }
 
     @Override
     public void releaseSeat(String memberEmail, SeatSelectionRequest seatSelectionRequest) {
-        reservationTransactionService.releaseSeat(memberEmail, seatSelectionRequest);
+        reservationService.releaseSeat(memberEmail, seatSelectionRequest);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/ticket/service/proxy/RedissonReservationServiceProxy.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/ticket/service/proxy/RedissonReservationServiceProxy.java
@@ -9,7 +9,7 @@ import com.thirdparty.ticketing.domain.common.ErrorCode;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.ticket.dto.request.SeatSelectionRequest;
 import com.thirdparty.ticketing.domain.ticket.dto.request.TicketPaymentRequest;
-import com.thirdparty.ticketing.domain.ticket.service.ReservationTransactionService;
+import com.thirdparty.ticketing.domain.ticket.service.ReservationService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RedissonReservationServiceProxy implements ReservationServiceProxy {
 
     private final RedissonClient redissonClient;
-    private final ReservationTransactionService reservationTransactionService;
+    private final ReservationService reservationService;
 
     private void performSeatAction(String seatId, Runnable action) {
         String lockPrefix = "seat:";
@@ -44,20 +44,18 @@ public class RedissonReservationServiceProxy implements ReservationServiceProxy 
     public void selectSeat(String memberEmail, SeatSelectionRequest seatSelectionRequest) {
         performSeatAction(
                 seatSelectionRequest.getSeatId().toString(),
-                () -> reservationTransactionService.selectSeat(memberEmail, seatSelectionRequest));
+                () -> reservationService.selectSeat(memberEmail, seatSelectionRequest));
     }
 
     @Override
     public void reservationTicket(String memberEmail, TicketPaymentRequest ticketPaymentRequest) {
         performSeatAction(
                 ticketPaymentRequest.getSeatId().toString(),
-                () ->
-                        reservationTransactionService.reservationTicket(
-                                memberEmail, ticketPaymentRequest));
+                () -> reservationService.reservationTicket(memberEmail, ticketPaymentRequest));
     }
 
     @Override
     public void releaseSeat(String memberEmail, SeatSelectionRequest seatSelectionRequest) {
-        reservationTransactionService.releaseSeat(memberEmail, seatSelectionRequest);
+        reservationService.releaseSeat(memberEmail, seatSelectionRequest);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/config/MessageRouterService.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/MessageRouterService.java
@@ -1,0 +1,46 @@
+package com.thirdparty.ticketing.global.config;
+
+import java.util.Map;
+
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MessageRouterService {
+
+    private final SeatSynchronizer seatSynchronizer;
+
+    @Transactional
+    public void consume(MapRecord<String, Object, Object> mapRecord, Runnable postProcess) {
+        // 왜 실행 안됨?
+        System.out.println("MessageId: {}" + mapRecord.getId());
+        System.out.println("Stream: {}" + mapRecord.getStream());
+        System.out.println("Body: {}" + mapRecord.getValue());
+
+        log.info("Received message: {}", mapRecord.getStream());
+
+        Map<Object, Object> message = mapRecord.getValue();
+        for (Object type : message.keySet()) {
+            String messageType = (String) type;
+            Long seatId = Long.valueOf((String) message.get(messageType));
+
+            switch (messageType) {
+                case "occupy":
+                    seatSynchronizer.occupy(seatId);
+                    break;
+                case "release":
+                    seatSynchronizer.release(seatId);
+                    break;
+                default:
+                    log.warn("Unknown message type: {}", messageType);
+            }
+        }
+        postProcess.run();
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/PendingMessageConsumer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/PendingMessageConsumer.java
@@ -1,0 +1,59 @@
+package com.thirdparty.ticketing.global.config;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@EnableScheduling
+@Component
+@RequiredArgsConstructor
+public class PendingMessageConsumer {
+
+    private final RedisOperator redisOperator;
+    private final RedisStreamConfig redisStreamConfig;
+    private final MessageRouterService messageRouterService;
+
+    @Scheduled(fixedRate = 1000)
+    public void consumePendingMessage() {
+
+        // 처리되지 않은 메시지 조회
+        PendingMessages pendingMessageInfos =
+                redisOperator.getPendingMessage(
+                        redisStreamConfig.getStreamKey(),
+                        redisStreamConfig.getConsumerGroupName(),
+                        redisStreamConfig.getConsumerName());
+
+        RecordId[] recordIds =
+                pendingMessageInfos.stream().map(PendingMessage::getId).toArray(RecordId[]::new);
+
+        // 처리되지 않은 메시지 데이터 조회
+        List<MapRecord<String, Object, Object>> messages =
+                redisOperator.claim(
+                        redisStreamConfig.getStreamKey(),
+                        redisStreamConfig.getConsumerGroupName(),
+                        redisStreamConfig.getConsumerName(),
+                        Duration.ofMinutes(1),
+                        recordIds);
+
+        // 메시지 처리
+        messages.forEach(
+                message -> {
+                    messageRouterService.consume(
+                            message,
+                            () ->
+                                    redisOperator.acknowledge(
+                                            redisStreamConfig.getConsumerGroupName(), message));
+                });
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/RedisOperator.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/RedisOperator.java
@@ -1,0 +1,121 @@
+package com.thirdparty.ticketing.global.config;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamInfo;
+import org.springframework.data.redis.connection.stream.StreamInfo.XInfoGroup;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.output.StatusOutput;
+import io.lettuce.core.protocol.CommandArgs;
+import io.lettuce.core.protocol.CommandKeyword;
+import io.lettuce.core.protocol.CommandType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class RedisOperator {
+    private final RedisConnectionFactory redisConnectionFactory;
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean isStreamConsumerGroupExist(String streamKey, String consumerGroupName) {
+        Iterator<XInfoGroup> iterator =
+                this.redisTemplate.opsForStream().groups(streamKey).stream().iterator();
+
+        while (iterator.hasNext()) {
+            StreamInfo.XInfoGroup xInfoGroup = iterator.next();
+            if (xInfoGroup.groupName().equals(consumerGroupName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void createStreamConsumerGroup(String streamKey, String consumerGroupName) {
+        // if stream is not exist, create stream and consumer group of it
+        if (Boolean.FALSE.equals(this.redisTemplate.hasKey(streamKey))) {
+            RedisAsyncCommands commands =
+                    (RedisAsyncCommands)
+                            redisConnectionFactory.getConnection().getNativeConnection();
+
+            CommandArgs<String, String> args =
+                    new CommandArgs<>(StringCodec.UTF8)
+                            .add(CommandKeyword.CREATE)
+                            .add(streamKey)
+                            .add(consumerGroupName)
+                            .add("0")
+                            .add("MKSTREAM");
+
+            commands.dispatch(CommandType.XGROUP, new StatusOutput(StringCodec.UTF8), args);
+        }
+        // stream is exist, create consumerGroup if is not exist
+        else {
+            if (!isStreamConsumerGroupExist(streamKey, consumerGroupName)) {
+                this.redisTemplate
+                        .opsForStream()
+                        .createGroup(streamKey, ReadOffset.from("0"), consumerGroupName);
+            }
+        }
+    }
+
+    public StreamMessageListenerContainer createStreamMessageListenerContainer() {
+        return StreamMessageListenerContainer.create(
+                redisConnectionFactory,
+                StreamMessageListenerContainer.StreamMessageListenerContainerOptions.builder()
+                        .hashKeySerializer(new StringRedisSerializer())
+                        .hashValueSerializer(new StringRedisSerializer())
+                        .pollTimeout(Duration.ofMillis(20))
+                        .build());
+    }
+
+    public void acknowledge(String consumerGroup, MapRecord<String, Object, Object> message) {
+        Long ack = this.redisTemplate.opsForStream().acknowledge(consumerGroup, message);
+        if (ack == 0) {
+            log.error("Acknowledge failed. MessageId: {}", message.getId());
+        } else {
+            log.info("Acknowledge success. MessageId: {}", message.getId());
+        }
+    }
+
+    public PendingMessages getPendingMessage(
+            String streamKey, String consumerGroup, String consumerName) {
+        return this.redisTemplate
+                .opsForStream()
+                .pending(
+                        streamKey,
+                        Consumer.from(consumerGroup, consumerName),
+                        Range.unbounded(),
+                        100L);
+    }
+
+    public List<MapRecord<String, Object, Object>> claim(
+            String streamKey,
+            String consumerGroup,
+            String consumerName,
+            Duration minIdleTime,
+            RecordId... messageIds) {
+        if (messageIds.length < 1) {
+            return List.of();
+        }
+
+        return this.redisTemplate
+                .opsForStream()
+                .claim(streamKey, consumerGroup, consumerName, minIdleTime, messageIds);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/RedisStreamConfig.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/RedisStreamConfig.java
@@ -1,0 +1,31 @@
+package com.thirdparty.ticketing.global.config;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+
+@Configuration
+public class RedisStreamConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private String redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Getter
+    @Value("${stream.key}")
+    private String streamKey;
+
+    @Getter
+    @Value("${stream.consumer.groupName}")
+    private String consumerGroupName;
+
+    @Getter private String consumerName = UUID.randomUUID().toString();
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/RedisStreamConsumer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/RedisStreamConsumer.java
@@ -1,0 +1,76 @@
+package com.thirdparty.ticketing.global.config;
+
+import java.time.Duration;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.stream.StreamListener;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.Subscription;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisStreamConsumer
+        implements StreamListener<String, MapRecord<String, Object, Object>> {
+
+    private final RedisOperator redisOperator;
+    private final RedisStreamConfig redisStreamConfig;
+    private final MessageRouterService messageRouterService;
+
+    private StreamMessageListenerContainer<String, MapRecord<String, Object, Object>>
+            listenerContainer;
+    private Subscription subscription;
+
+    @Override
+    public void onMessage(MapRecord<String, Object, Object> message) {
+        messageRouterService.consume(
+                message,
+                () -> redisOperator.acknowledge(redisStreamConfig.getConsumerGroupName(), message));
+    }
+
+    @PostConstruct
+    public void init() throws InterruptedException {
+        // Consumer Group 설정
+        this.redisOperator.createStreamConsumerGroup(
+                redisStreamConfig.getStreamKey(), redisStreamConfig.getConsumerGroupName());
+
+        // StreamMessageListenerContainer 설정
+        this.listenerContainer = this.redisOperator.createStreamMessageListenerContainer();
+
+        // Subscription 설정
+        this.subscription =
+                this.listenerContainer.receive(
+                        Consumer.from(
+                                redisStreamConfig.getConsumerGroupName(),
+                                redisStreamConfig.getConsumerName()),
+                        StreamOffset.create(
+                                redisStreamConfig.getStreamKey(), ReadOffset.lastConsumed()),
+                        this);
+
+        // redis stream 구독 생성까지 Blocking 된다. 이때의 timeout 2초다. 만약 2초보다 빠르게 구독이 생성되면 바로 다음으로 넘어간다.
+        this.subscription.await(Duration.ofSeconds(2));
+
+        // redis listen 시작
+        this.listenerContainer.start();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (this.subscription != null) {
+            this.subscription.cancel();
+        }
+        if (this.listenerContainer != null) {
+            this.listenerContainer.stop();
+        }
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
 import com.thirdparty.ticketing.domain.common.EventPublisher;
-import com.thirdparty.ticketing.domain.common.LettuceRepository;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
 import com.thirdparty.ticketing.domain.payment.PaymentProcessor;
 import com.thirdparty.ticketing.domain.seat.repository.LettuceSeatRepository;
@@ -22,6 +21,7 @@ import com.thirdparty.ticketing.domain.ticket.service.strategy.PessimisticLockSe
 
 @Configuration
 public class ReservationServiceContainer {
+
     @Bean
     @Primary
     public ReservationService redissonReservationServiceProxy(
@@ -31,8 +31,8 @@ public class ReservationServiceContainer {
 
     @Bean
     public ReservationService lettuceReservationServiceProxy(
-            LettuceRepository lettuceRepository, ReservationRedisService reservationRedisService) {
-        return new LettuceReservationServiceProxy(lettuceRepository, reservationRedisService);
+            ReservationRedisService reservationRedisService) {
+        return new LettuceReservationServiceProxy(reservationRedisService);
     }
 
     @Bean

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 import com.thirdparty.ticketing.domain.common.EventPublisher;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
@@ -55,14 +56,16 @@ public class ReservationServiceContainer {
             MemberRepository memberRepository,
             LettuceSeatRepository lettuceSeatRepository,
             EventPublisher eventPublisher,
-            SeatRepository seatRepository) {
+            SeatRepository seatRepository,
+            StringRedisTemplate redisTemplate) {
         return new ReservationRedisService(
                 memberRepository,
                 eventPublisher,
                 paymentProcessor,
                 lettuceSeatRepository,
                 seatRepository,
-                ticketRepository);
+                ticketRepository,
+                redisTemplate);
     }
 
     @Bean

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -1,6 +1,5 @@
 package com.thirdparty.ticketing.global.config;
 
-import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,8 +24,8 @@ public class ReservationServiceContainer {
     @Bean
     @Primary
     public ReservationService redissonReservationServiceProxy(
-            RedissonClient redissonClient, ReservationRedisService reservationRedisService) {
-        return new RedissonReservationServiceProxy(redissonClient, reservationRedisService);
+            ReservationRedisService reservationRedisService) {
+        return new RedissonReservationServiceProxy(reservationRedisService);
     }
 
     @Bean

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -23,13 +23,13 @@ import com.thirdparty.ticketing.domain.ticket.service.strategy.PessimisticLockSe
 @Configuration
 public class ReservationServiceContainer {
     @Bean
+    @Primary
     public ReservationService redissonReservationServiceProxy(
             RedissonClient redissonClient, ReservationRedisService reservationRedisService) {
         return new RedissonReservationServiceProxy(redissonClient, reservationRedisService);
     }
 
     @Bean
-    @Primary
     public ReservationService lettuceReservationServiceProxy(
             LettuceRepository lettuceRepository, ReservationRedisService reservationRedisService) {
         return new LettuceReservationServiceProxy(lettuceRepository, reservationRedisService);

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -29,12 +29,12 @@ public class ReservationServiceContainer {
     }
 
     @Bean
+    @Primary
     public ReservationService lettuceReservationServiceProxy(
             LettuceRepository lettuceRepository, ReservationRedisService reservationRedisService) {
         return new LettuceReservationServiceProxy(lettuceRepository, reservationRedisService);
     }
 
-    @Primary
     @Bean
     ReservationService optimisticReservationServiceProxy(
             @Qualifier("persistenceOptimisticReservationService")

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -62,7 +62,8 @@ public class ReservationServiceContainer {
             MemberRepository memberRepository,
             LettuceSeatRepository lettuceSeatRepository,
             EventPublisher eventPublisher,
-            ReservationManager reservationManager) {
+            @Qualifier("reservationManagerTransactionalImpl")
+                    ReservationManager reservationManager) {
         return new ReservationRedisService(
                 memberRepository,
                 eventPublisher,
@@ -79,7 +80,8 @@ public class ReservationServiceContainer {
             MemberRepository memberRepository,
             SeatRepository seatRepository,
             EventPublisher eventPublisher,
-            ReservationManager reservationManager) {
+            @Qualifier("reservationManagerTransactionalImpl")
+                    ReservationManager reservationManager) {
         LockSeatStrategy lockSeatStrategy = new NaiveSeatStrategy(seatRepository);
         return new ReservationTransactionService(
                 ticketRepository,
@@ -97,7 +99,7 @@ public class ReservationServiceContainer {
             MemberRepository memberRepository,
             SeatRepository seatRepository,
             EventPublisher eventPublisher,
-            ReservationManager reservationManager) {
+            ReservationManagerTransactionalImpl reservationManagerTransactionalImpl) {
         LockSeatStrategy lockSeatStrategy = new OptimisticLockSeatStrategy(seatRepository);
         return new ReservationTransactionService(
                 ticketRepository,
@@ -105,7 +107,7 @@ public class ReservationServiceContainer {
                 paymentProcessor,
                 lockSeatStrategy,
                 eventPublisher,
-                reservationManager);
+                reservationManagerTransactionalImpl);
     }
 
     @Bean
@@ -115,7 +117,7 @@ public class ReservationServiceContainer {
             MemberRepository memberRepository,
             SeatRepository seatRepository,
             EventPublisher eventPublisher,
-            ReservationManager reservationManager) {
+            ReservationManagerTransactionalImpl reservationManagerTransactionalImpl) {
         LockSeatStrategy lockSeatStrategy = new PessimisticLockSeatStrategy(seatRepository);
         return new ReservationTransactionService(
                 ticketRepository,
@@ -123,6 +125,6 @@ public class ReservationServiceContainer {
                 paymentProcessor,
                 lockSeatStrategy,
                 eventPublisher,
-                reservationManager);
+                reservationManagerTransactionalImpl);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -10,6 +10,7 @@ import com.thirdparty.ticketing.domain.common.EventPublisher;
 import com.thirdparty.ticketing.domain.common.LettuceRepository;
 import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
 import com.thirdparty.ticketing.domain.payment.PaymentProcessor;
+import com.thirdparty.ticketing.domain.seat.repository.LettuceSeatRepository;
 import com.thirdparty.ticketing.domain.seat.repository.SeatRepository;
 import com.thirdparty.ticketing.domain.ticket.repository.TicketRepository;
 import com.thirdparty.ticketing.domain.ticket.service.*;
@@ -52,6 +53,23 @@ public class ReservationServiceContainer {
             @Qualifier("persistencePessimisticReservationService")
                     ReservationTransactionService persistencePessimisticReservationService) {
         return new PessimisticReservationServiceProxy(persistencePessimisticReservationService);
+    }
+
+    @Bean
+    public ReservationRedisService reservationRedisService(
+            TicketRepository ticketRepository,
+            PaymentProcessor paymentProcessor,
+            MemberRepository memberRepository,
+            LettuceSeatRepository lettuceSeatRepository,
+            EventPublisher eventPublisher,
+            ReservationManager reservationManager) {
+        return new ReservationRedisService(
+                memberRepository,
+                eventPublisher,
+                paymentProcessor,
+                lettuceSeatRepository,
+                reservationManager,
+                ticketRepository);
     }
 
     @Bean

--- a/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/ReservationServiceContainer.java
@@ -24,20 +24,14 @@ import com.thirdparty.ticketing.domain.ticket.service.strategy.PessimisticLockSe
 public class ReservationServiceContainer {
     @Bean
     public ReservationService redissonReservationServiceProxy(
-            RedissonClient redissonClient,
-            @Qualifier("cacheReservationTransactionService")
-                    ReservationTransactionService cacheReservationTransactionService) {
-        return new RedissonReservationServiceProxy(
-                redissonClient, cacheReservationTransactionService);
+            RedissonClient redissonClient, ReservationRedisService reservationRedisService) {
+        return new RedissonReservationServiceProxy(redissonClient, reservationRedisService);
     }
 
     @Bean
     public ReservationService lettuceReservationServiceProxy(
-            LettuceRepository lettuceRepository,
-            @Qualifier("cacheReservationTransactionService")
-                    ReservationTransactionService cacheReservationTransactionService) {
-        return new LettuceReservationServiceProxy(
-                lettuceRepository, cacheReservationTransactionService);
+            LettuceRepository lettuceRepository, ReservationRedisService reservationRedisService) {
+        return new LettuceReservationServiceProxy(lettuceRepository, reservationRedisService);
     }
 
     @Primary
@@ -62,14 +56,13 @@ public class ReservationServiceContainer {
             MemberRepository memberRepository,
             LettuceSeatRepository lettuceSeatRepository,
             EventPublisher eventPublisher,
-            @Qualifier("reservationManagerTransactionalImpl")
-                    ReservationManager reservationManager) {
+            SeatRepository seatRepository) {
         return new ReservationRedisService(
                 memberRepository,
                 eventPublisher,
                 paymentProcessor,
                 lettuceSeatRepository,
-                reservationManager,
+                seatRepository,
                 ticketRepository);
     }
 

--- a/src/main/java/com/thirdparty/ticketing/global/config/SeatSynchronizer.java
+++ b/src/main/java/com/thirdparty/ticketing/global/config/SeatSynchronizer.java
@@ -1,0 +1,67 @@
+package com.thirdparty.ticketing.global.config;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.domain.member.Member;
+import com.thirdparty.ticketing.domain.member.repository.MemberRepository;
+import com.thirdparty.ticketing.domain.seat.RedisSeat;
+import com.thirdparty.ticketing.domain.seat.Seat;
+import com.thirdparty.ticketing.domain.seat.repository.LettuceSeatRepository;
+import com.thirdparty.ticketing.domain.seat.repository.SeatRepository;
+import com.thirdparty.ticketing.global.lock.redisson.RedissonLockAnnotation;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SeatSynchronizer {
+
+    private final LettuceSeatRepository lettuceSeatRepository;
+    private final SeatRepository seatRepository;
+    private final MemberRepository memberRepository;
+
+    @RedissonLockAnnotation(key = "#seatId")
+    @Transactional
+    public void occupy(Long seatId) {
+        RedisSeat redisSeat =
+                lettuceSeatRepository
+                        .findBySeatId(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+
+        Seat seat =
+                seatRepository
+                        .findById(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+
+        Member member =
+                memberRepository
+                        .findById(redisSeat.getMemberId())
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_MEMBER));
+
+        seat.assignByMember(member);
+    }
+
+    @RedissonLockAnnotation(key = "#seatId")
+    @Transactional
+    public void release(Long seatId) {
+        RedisSeat redisSeat =
+                lettuceSeatRepository
+                        .findBySeatId(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+
+        Seat seat =
+                seatRepository
+                        .findById(seatId)
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_SEAT));
+
+        Member member =
+                memberRepository
+                        .findById(redisSeat.getMemberId())
+                        .orElseThrow(() -> new TicketingException(ErrorCode.NOT_FOUND_MEMBER));
+
+        seat.releaseSeat(member);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/lock/CustomSpringELParser.java
+++ b/src/main/java/com/thirdparty/ticketing/global/lock/CustomSpringELParser.java
@@ -1,0 +1,20 @@
+package com.thirdparty.ticketing.global.lock;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {}
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/lock/lettuce/LettuceLockAnnotation.java
+++ b/src/main/java/com/thirdparty/ticketing/global/lock/lettuce/LettuceLockAnnotation.java
@@ -1,0 +1,16 @@
+package com.thirdparty.ticketing.global.lock.lettuce;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LettuceLockAnnotation {
+    String key(); // SpEL 표현식으로 Lock 키를 결정
+
+    int retryLimit() default 5; // 기본 재시도 횟수
+
+    int sleepDuration() default 300; // 기본 슬립 시간 (밀리초)
+}

--- a/src/main/java/com/thirdparty/ticketing/global/lock/lettuce/LettuceLockAspect.java
+++ b/src/main/java/com/thirdparty/ticketing/global/lock/lettuce/LettuceLockAspect.java
@@ -1,0 +1,80 @@
+package com.thirdparty.ticketing.global.lock.lettuce;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.expression.MethodBasedEvaluationContext;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.stereotype.Component;
+
+import com.thirdparty.ticketing.domain.common.ErrorCode;
+import com.thirdparty.ticketing.domain.common.LettuceRepository;
+import com.thirdparty.ticketing.domain.common.TicketingException;
+import com.thirdparty.ticketing.global.lock.CustomSpringELParser;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+public class LettuceLockAspect {
+
+    @Autowired private LettuceRepository lettuceRepository;
+
+    private final SpelExpressionParser spelExpressionParser = new SpelExpressionParser();
+
+    private static final String LETTUCE_LOCK_PREFIX = "seat-lock-";
+
+    @Around("@annotation(com.thirdparty.ticketing.global.lock.lettuce.LettuceLockAnnotation)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        LettuceLockAnnotation lettuceLockAnnotation =
+                method.getAnnotation(LettuceLockAnnotation.class);
+        String lockKey =
+                LETTUCE_LOCK_PREFIX
+                        + CustomSpringELParser.getDynamicValue(
+                                signature.getParameterNames(),
+                                joinPoint.getArgs(),
+                                lettuceLockAnnotation.key());
+
+        int retryLimit = lettuceLockAnnotation.retryLimit();
+        int sleepDuration = lettuceLockAnnotation.sleepDuration();
+
+        try {
+            while (retryLimit > 0 && !lettuceRepository.seatLock(lockKey)) {
+                retryLimit -= 1;
+                Thread.sleep(sleepDuration);
+            }
+
+            if (retryLimit > 0) {
+                return joinPoint.proceed();
+            } else {
+                throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
+            }
+
+        } catch (InterruptedException e) {
+            throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT, e);
+        } finally {
+            lettuceRepository.unlock(lockKey);
+        }
+    }
+
+    private String parseSpel(String spel, ProceedingJoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Object rootObject = joinPoint.getTarget(); // 메서드가 호출된 대상 객체
+        MethodBasedEvaluationContext context =
+                new MethodBasedEvaluationContext(
+                        rootObject,
+                        methodSignature.getMethod(), // Method
+                        joinPoint.getArgs(), // Method Arguments
+                        new DefaultParameterNameDiscoverer() // Parameter Name Discoverer
+                        );
+        return spelExpressionParser.parseExpression(spel).getValue(context, String.class);
+    }
+}

--- a/src/main/java/com/thirdparty/ticketing/global/lock/redisson/RedissonLockAnnotation.java
+++ b/src/main/java/com/thirdparty/ticketing/global/lock/redisson/RedissonLockAnnotation.java
@@ -1,0 +1,16 @@
+package com.thirdparty.ticketing.global.lock.redisson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedissonLockAnnotation {
+    String key(); // SpEL 표현식으로 Lock 키를 결정
+
+    int waitTime() default 1; // 기본 대기 시간
+
+    int lockTTL() default 60; // 락의 TTL
+}

--- a/src/main/java/com/thirdparty/ticketing/global/lock/redisson/RedissonLockAspect.java
+++ b/src/main/java/com/thirdparty/ticketing/global/lock/redisson/RedissonLockAspect.java
@@ -1,16 +1,18 @@
-package com.thirdparty.ticketing.global.lock.lettuce;
+package com.thirdparty.ticketing.global.lock.redisson;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.thirdparty.ticketing.domain.common.ErrorCode;
-import com.thirdparty.ticketing.domain.common.LettuceRepository;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.global.lock.CustomSpringELParser;
 
@@ -19,44 +21,39 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Aspect
 @Component
-public class LettuceLockAspect {
+public class RedissonLockAspect {
 
-    @Autowired private LettuceRepository lettuceRepository;
+    @Autowired private RedissonClient redissonClient;
 
-    private static final String LETTUCE_LOCK_PREFIX = "seat-lock-";
+    private static final String REDISSON_LOCK_PREFIX = "seat-lock-";
 
-    @Around("@annotation(com.thirdparty.ticketing.global.lock.lettuce.LettuceLockAnnotation)")
+    @Around("@annotation(com.thirdparty.ticketing.global.lock.redisson.RedissonLockAnnotation)")
     public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
-        LettuceLockAnnotation lettuceLockAnnotation =
-                method.getAnnotation(LettuceLockAnnotation.class);
+        RedissonLockAnnotation redissonLockAnnotation =
+                method.getAnnotation(RedissonLockAnnotation.class);
         String lockKey =
-                LETTUCE_LOCK_PREFIX
+                REDISSON_LOCK_PREFIX
                         + CustomSpringELParser.getDynamicValue(
                                 signature.getParameterNames(),
                                 joinPoint.getArgs(),
-                                lettuceLockAnnotation.key());
+                                redissonLockAnnotation.key());
 
-        int retryLimit = lettuceLockAnnotation.retryLimit();
-        int sleepDuration = lettuceLockAnnotation.sleepDuration();
+        int waitTime = redissonLockAnnotation.waitTime();
+        int lockTTL = redissonLockAnnotation.lockTTL();
+
+        RLock lock = redissonClient.getLock(lockKey);
 
         try {
-            while (retryLimit > 0 && !lettuceRepository.seatLock(lockKey)) {
-                retryLimit -= 1;
-                Thread.sleep(sleepDuration);
+            if (!lock.tryLock(waitTime, lockTTL, TimeUnit.SECONDS)) {
+                return false;
             }
-
-            if (retryLimit > 0) {
-                return joinPoint.proceed();
-            } else {
-                throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT);
-            }
-
+            return joinPoint.proceed();
         } catch (InterruptedException e) {
             throw new TicketingException(ErrorCode.NOT_SELECTABLE_SEAT, e);
         } finally {
-            lettuceRepository.unlock(lockKey);
+            lock.unlock();
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/domain/ticket/service/CacheReservationTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/ticket/service/CacheReservationTest.java
@@ -95,6 +95,9 @@ public class CacheReservationTest extends BaseIntegrationTest {
                                 .seatCode("R")
                                 .seatStatus(SeatStatus.SELECTABLE)
                                 .build());
+        // seat의 id가
+        RedisSeat redisSeat = new RedisSeat(seat.getSeatId(), null, SeatStatus.SELECTABLE);
+        lettuceSeatRepository.update(redisSeat);
     }
 
     @AfterEach
@@ -104,6 +107,7 @@ public class CacheReservationTest extends BaseIntegrationTest {
         seatGradeRepository.deleteAll();
         performanceRepository.deleteAll();
         memberRepository.deleteAll();
+        stringRedisTemplate.getConnectionFactory().getConnection().flushAll();
     }
 
     @Test


### PR DESCRIPTION
### ⛏ 작업 사항
![CleanShot 2024-08-28 at 21 55 01](https://github.com/user-attachments/assets/b11b3f19-eecf-40f8-b489-369aacabbd4f)

기존의 분산락의 성능이 나오지 않아, 이벤트 기반으로 Redis의 정보를 RDB에 최신화 하려는 로직을 작성. Redis에 자리에 대한 최신 정보가 있다고 가정하고 RDB는 일종의 백업 저장소로 사용한다.

### 📝 작업 요약

1. 유저가 자리를 차지할 때 다음과 같은 일이 발생한다.
   * Redis에 자리 정보가 기록된다.
   * occupy라는 이벤트가 발생 (RDB에 자리를 차지한 유저를 최산화 하기 위한 발생하는 이벤트)
   * 스케쥴러에 20초후 작동할 작업 발생 (20초 후에 자리를 포기하는 release 이벤트 발생)
2. 유저가 결제하면 다음과 같은 일이 발생한다.
  * 결제는 정합성이 중요하다고 생각해서 Redis와 RDB에 동시에 기록
3. release, occupy 이벤트
  * 해당 이벤트는 각각 Redis에 기록된 자리 포기, 자리 점유 이후 상태를 디비에 써주는 이벤트

<br>
이론으로 보면 완벽하지만 Redis와 RDB간의 정합성을 짧은 시간 안에 달성하기 힘들어 포기하였다.

### 💡 관련 이슈
- close #
