### PR TITLE
Feature: 대기열 페이지에서 빠져나간 사용자와 대기한 사용자를 구분한다. 

### DIFF
--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/LastPollingEvent.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/LastPollingEvent.java
@@ -1,0 +1,13 @@
+package com.thirdparty.ticketing.domain.waitingsystem;
+
+import com.thirdparty.ticketing.domain.common.Event;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LastPollingEvent implements Event {
+
+    private final String email;
+    private final long performanceId;
+}

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/LastPollingEvent.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/LastPollingEvent.java
@@ -1,6 +1,7 @@
 package com.thirdparty.ticketing.domain.waitingsystem;
 
 import com.thirdparty.ticketing.domain.common.Event;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
@@ -27,8 +27,12 @@ public class WaitingSystem {
     public long getRemainingCount(String email, long performanceId) {
         WaitingMember waitingMember = waitingManager.findWaitingMember(email, performanceId);
         long runningCount = runningManager.getRunningCount(performanceId);
+        long remainingCount = waitingMember.getWaitingCount() - runningCount;
         eventPublisher.publish(new PollingEvent(performanceId));
-        return waitingMember.getWaitingCount() - runningCount;
+        if (remainingCount <= 0) {
+            eventPublisher.publish(new LastPollingEvent(email, performanceId));
+        }
+        return remainingCount;
     }
 
     public void moveUserToRunning(long performanceId) {
@@ -43,5 +47,9 @@ public class WaitingSystem {
     public void pullOutRunningMember(String email, long performanceId) {
         runningManager.pullOutRunningMember(email, performanceId);
         waitingManager.removeMemberInfo(email, performanceId);
+    }
+
+    public void updateRunningMemberExpiredTime(String email, long performanceId) {
+        runningManager.updateRunningMemberExpiredTime(email, performanceId);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
@@ -51,6 +51,7 @@ public class WaitingSystem {
 
     /**
      * 공연에 해당하는 사용자의 작업 공간 만료 시간을 5분 뒤로 업데이트한다.
+     *
      * @param email 사용자의 이메일
      * @param performanceId 공연 ID
      */

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystem.java
@@ -49,6 +49,11 @@ public class WaitingSystem {
         waitingManager.removeMemberInfo(email, performanceId);
     }
 
+    /**
+     * 공연에 해당하는 사용자의 작업 공간 만료 시간을 5분 뒤로 업데이트한다.
+     * @param email 사용자의 이메일
+     * @param performanceId 공연 ID
+     */
     public void updateRunningMemberExpiredTime(String email, long performanceId) {
         runningManager.updateRunningMemberExpiredTime(email, performanceId);
     }

--- a/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/domain/waitingsystem/running/RunningManager.java
@@ -16,4 +16,6 @@ public interface RunningManager {
     void pullOutRunningMember(String email, long performanceId);
 
     Set<String> removeExpiredMemberInfo(long performanceId);
+
+    void updateRunningMemberExpiredTime(String email, long performanceId);
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListener.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListener.java
@@ -1,6 +1,5 @@
 package com.thirdparty.ticketing.global.waitingsystem;
 
-import com.thirdparty.ticketing.domain.waitingsystem.LastPollingEvent;
 import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +12,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import com.thirdparty.ticketing.domain.common.ErrorCode;
 import com.thirdparty.ticketing.domain.common.TicketingException;
 import com.thirdparty.ticketing.domain.ticket.dto.event.PaymentEvent;
+import com.thirdparty.ticketing.domain.waitingsystem.LastPollingEvent;
 import com.thirdparty.ticketing.domain.waitingsystem.PollingEvent;
 import com.thirdparty.ticketing.domain.waitingsystem.WaitingSystem;
 

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListener.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListener.java
@@ -1,5 +1,6 @@
 package com.thirdparty.ticketing.global.waitingsystem;
 
+import com.thirdparty.ticketing.domain.waitingsystem.LastPollingEvent;
 import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,6 +26,11 @@ public class WaitingEventListener {
     @EventListener(PollingEvent.class)
     public void moveUserToRunningRoom(PollingEvent event) {
         waitingSystem.moveUserToRunning(event.getPerformanceId());
+    }
+
+    @EventListener(LastPollingEvent.class)
+    public void updateRunningMemberExpiredTime(LastPollingEvent event) {
+        waitingSystem.updateRunningMemberExpiredTime(event.getEmail(), event.getPerformanceId());
     }
 
     @TransactionalEventListener(PaymentEvent.class)

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -47,6 +47,6 @@ public class MemoryRunningManager implements RunningManager {
 
     @Override
     public void updateRunningMemberExpiredTime(String email, long performanceId) {
-
+        runningRoom.updateRunningMemberExpiredTime(email, performanceId);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningManager.java
@@ -44,4 +44,9 @@ public class MemoryRunningManager implements RunningManager {
     public Set<String> removeExpiredMemberInfo(long performanceId) {
         return runningRoom.removeExpiredMemberInfo(performanceId);
     }
+
+    @Override
+    public void updateRunningMemberExpiredTime(String email, long performanceId) {
+
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
@@ -69,4 +69,20 @@ public class MemoryRunningRoom implements RunningRoom {
         removeMemberEmails.forEach(performanceRoom::remove);
         return removeMemberEmails;
     }
+
+    public void updateRunningMemberExpiredTime(String email, long performanceId) {
+        room.computeIfPresent(performanceId,
+                (key, room) -> {
+                    room.computeIfPresent(email, (k, waitingMember) ->
+                            new WaitingMember(
+                                    email,
+                                    performanceId,
+                                    waitingMember.getWaitingCount(),
+                                    ZonedDateTime.now().plusMinutes(5)
+                            ));
+                    return room;
+                }
+        );
+
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoom.java
@@ -71,18 +71,18 @@ public class MemoryRunningRoom implements RunningRoom {
     }
 
     public void updateRunningMemberExpiredTime(String email, long performanceId) {
-        room.computeIfPresent(performanceId,
+        room.computeIfPresent(
+                performanceId,
                 (key, room) -> {
-                    room.computeIfPresent(email, (k, waitingMember) ->
-                            new WaitingMember(
-                                    email,
-                                    performanceId,
-                                    waitingMember.getWaitingCount(),
-                                    ZonedDateTime.now().plusMinutes(5)
-                            ));
+                    room.computeIfPresent(
+                            email,
+                            (k, waitingMember) ->
+                                    new WaitingMember(
+                                            email,
+                                            performanceId,
+                                            waitingMember.getWaitingCount(),
+                                            ZonedDateTime.now().plusMinutes(5)));
                     return room;
-                }
-        );
-
+                });
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -44,4 +44,9 @@ public class RedisRunningManager implements RunningManager {
     public Set<String> removeExpiredMemberInfo(long performanceId) {
         return runningRoom.removeExpiredMemberInfo(performanceId);
     }
+
+    @Override
+    public void updateRunningMemberExpiredTime(String email, long performanceId) {
+
+    }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -31,8 +31,8 @@ public class RedisRunningManager implements RunningManager {
 
     @Override
     public void enterRunningRoom(long performanceId, Set<WaitingMember> waitingMembers) {
-        runningCounter.increment(performanceId, waitingMembers.size());
         runningRoom.enter(performanceId, waitingMembers);
+        runningCounter.increment(performanceId, waitingMembers.size());
     }
 
     @Override

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningManager.java
@@ -47,6 +47,6 @@ public class RedisRunningManager implements RunningManager {
 
     @Override
     public void updateRunningMemberExpiredTime(String email, long performanceId) {
-
+        runningRoom.updateRunningMemberExpiredTime(email, performanceId);
     }
 }

--- a/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
+++ b/src/main/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoom.java
@@ -38,8 +38,7 @@ public class RedisRunningRoom implements RunningRoom {
         if (waitingMembers.isEmpty()) {
             return;
         }
-        ZonedDateTime minimumRunningTime = ZonedDateTime.now()
-                .plusSeconds(MINIMUM_RUNNING_TIME);
+        ZonedDateTime minimumRunningTime = ZonedDateTime.now().plusSeconds(MINIMUM_RUNNING_TIME);
         Set<TypedTuple<String>> collect =
                 waitingMembers.stream()
                         .map(
@@ -61,6 +60,7 @@ public class RedisRunningRoom implements RunningRoom {
 
     /**
      * 주어진 공연에 해당하는 러닝룸에서 만료 시간이 현재 시간 이전인 사람들을 제거한다.
+     *
      * @param performanceId
      * @return
      */
@@ -73,14 +73,16 @@ public class RedisRunningRoom implements RunningRoom {
     }
 
     /**
-     * 주어진 공연 - 이메일에 해당하는 사용자의 러닝룸 만료시간을 5분뒤로 업데이트 한다.
-     * 동시성 문제가 발생할 수 있다.
+     * 주어진 공연 - 이메일에 해당하는 사용자의 러닝룸 만료시간을 5분뒤로 업데이트 한다. 동시성 문제가 발생할 수 있다.
+     *
      * @param email 사용자의 이메일
      * @param performanceId 공연 ID
      */
     public void updateRunningMemberExpiredTime(String email, long performanceId) {
-        if(runningRoom.score(getRunningRoomKey(performanceId), email) != null) {
-            runningRoom.add(getRunningRoomKey(performanceId), email,
+        if (runningRoom.score(getRunningRoomKey(performanceId), email) != null) {
+            runningRoom.add(
+                    getRunningRoomKey(performanceId),
+                    email,
                     ZonedDateTime.now().plusMinutes(EXPIRED_MINUTE).toEpochSecond());
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
+++ b/src/test/java/com/thirdparty/ticketing/domain/waitingsystem/WaitingSystemTest.java
@@ -137,7 +137,7 @@ class WaitingSystemTest extends BaseIntegrationTest {
         void removeExpiredMemberInfoFromRunningRoom() {
             // given
             String anotherEmail = "anotherEmail@email.com";
-            ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now().plusSeconds(30);
             rawRunningRoom.add(getRunningRoomKey(performanceId), anotherEmail, now.toEpochSecond());
 
             // when
@@ -153,7 +153,7 @@ class WaitingSystemTest extends BaseIntegrationTest {
         void removeExpiredMemberInfoFromWaitingRoom() throws JsonProcessingException {
             // given
             String anotherEmail = "anotherEmail@email.com";
-            ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now().plusSeconds(30);
             WaitingMember waitingMember = new WaitingMember(anotherEmail, performanceId, 2, now);
             rawRunningRoom.add(getRunningRoomKey(performanceId), anotherEmail, now.toEpochSecond());
             rawWaitingRoom.put(

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/WaitingEventListenerTest.java
@@ -1,7 +1,12 @@
 package com.thirdparty.ticketing.global.waitingsystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,14 +20,18 @@ import org.springframework.data.redis.core.ZSetOperations;
 import com.thirdparty.ticketing.domain.common.EventPublisher;
 import com.thirdparty.ticketing.domain.waitingsystem.WaitingSystem;
 import com.thirdparty.ticketing.support.BaseIntegrationTest;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 class WaitingEventListenerTest extends BaseIntegrationTest {
 
-    @Autowired private WaitingSystem waitingSystem;
+    @Autowired
+    private WaitingSystem waitingSystem;
 
-    @Autowired private EventPublisher eventPublisher;
+    @Autowired
+    private EventPublisher eventPublisher;
 
-    @Autowired private StringRedisTemplate redisTemplate;
+    @Autowired
+    private StringRedisTemplate redisTemplate;
 
     private ZSetOperations<String, String> rawRunningRoom;
 
@@ -30,6 +39,10 @@ class WaitingEventListenerTest extends BaseIntegrationTest {
     void setUp() {
         rawRunningRoom = redisTemplate.opsForZSet();
         redisTemplate.getConnectionFactory().getConnection().commands().flushAll();
+    }
+
+    private String getRunningRoomKey(long performanceId) {
+        return "running_room:" + performanceId;
     }
 
     @Nested
@@ -52,6 +65,73 @@ class WaitingEventListenerTest extends BaseIntegrationTest {
             Set<String> members = rawRunningRoom.range("running_room:" + performanceId, 0, -1);
             System.out.println("회원 목록 출력 " + members);
             assertThat(waitingSystem.isReadyToHandle(email, performanceId)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("마지막 폴링 이벤트 발행 시")
+    class PublishLastPollingEventTest {
+
+        @Test
+        @DisplayName("작업 공간의 사용자 만료 시간을 업데이트한다.")
+        void updateRunningMemberExpiredTime() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+
+            waitingSystem.enterWaitingRoom(email, performanceId);
+            waitingSystem.moveUserToRunning(performanceId);
+
+            //when
+            waitingSystem.getRemainingCount(email, performanceId);
+
+            //then
+            Set<TypedTuple<String>> tuples = rawRunningRoom.rangeWithScores(getRunningRoomKey(performanceId), 0,
+                    -1);
+            assertThat(tuples)
+                    .hasSize(1)
+                    .first()
+                    .satisfies(tuple -> {
+                        ZonedDateTime memberExpiredTime = ZonedDateTime.ofInstant(
+                                Instant.ofEpochSecond(tuple.getScore().longValue()),
+                                ZoneId.of("Asia/Seoul"));
+                        assertThat(memberExpiredTime)
+                                .isCloseTo(ZonedDateTime.now().plusMinutes(5),
+                                        within(5, ChronoUnit.MINUTES));
+                    });
+        }
+
+        @Test
+        @DisplayName("이메일에 해당하는 사용자만 업데이트한다.")
+        void updateOnlyInputMember() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            String anotherEmail = "anotherEmail@email.com";
+
+            waitingSystem.enterWaitingRoom(email, performanceId);
+            waitingSystem.enterWaitingRoom(anotherEmail, performanceId);
+            waitingSystem.moveUserToRunning(performanceId);
+
+            //when
+            waitingSystem.getRemainingCount(email, performanceId);
+
+            //then
+            Set<TypedTuple<String>> tuples = rawRunningRoom.rangeWithScores(getRunningRoomKey(performanceId), 0,
+                    -1);
+            TypedTuple<String> emailMember = tuples.stream().filter(tuple -> tuple.getValue().equals(email))
+                    .findFirst().get();
+            TypedTuple<String> anotherEmailMember = tuples.stream()
+                    .filter(tuple -> tuple.getValue().equals(anotherEmail))
+                    .findFirst().get();
+            assertThat(getTime(emailMember.getScore())).isCloseTo(ZonedDateTime.now().plusMinutes(5),
+                    within(1, ChronoUnit.MINUTES));
+            assertThat(getTime(anotherEmailMember.getScore())).isCloseTo(ZonedDateTime.now().plusSeconds(30),
+                    within(5, ChronoUnit.SECONDS));
+        }
+
+        private ZonedDateTime getTime(Double score) {
+            return ZonedDateTime.ofInstant(Instant.ofEpochSecond(score.longValue()), ZoneId.of("Asia/Seoul"));
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
@@ -227,33 +227,34 @@ class MemoryRunningRoomTest {
         @Test
         @DisplayName("사용자의 만료 시간을 5분으로 업데이트 한다.")
         void updateRunningMemberExpiredTime() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             runningRoom.enter(performanceId, Set.of(new WaitingMember(email, performanceId)));
 
-            //when
+            // when
             runningRoom.updateRunningMemberExpiredTime(email, performanceId);
 
-            //then
+            // then
             WaitingMember waitingMember = room.get(performanceId).get(email);
-            assertThat(waitingMember.getEnteredAt()).isCloseTo(ZonedDateTime.now().plusMinutes(5),
-                    within(1, ChronoUnit.SECONDS));
+            assertThat(waitingMember.getEnteredAt())
+                    .isCloseTo(ZonedDateTime.now().plusMinutes(5), within(1, ChronoUnit.SECONDS));
         }
 
         @Test
         @DisplayName("사용자가 작업 공간에 존재하지 않으면 무시한다.")
         void ignore_notExistsMember() {
-            //given
+            // given
             long performanceId = 1;
             String email = "email@email.com";
             room.put(performanceId, new ConcurrentHashMap<>());
 
-            //when
-            Exception exception = catchException(
-                    () -> runningRoom.updateRunningMemberExpiredTime(email, performanceId));
+            // when
+            Exception exception =
+                    catchException(
+                            () -> runningRoom.updateRunningMemberExpiredTime(email, performanceId));
 
-            //then
+            // then
             assertThat(exception).doesNotThrowAnyException();
         }
     }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/memory/running/MemoryRunningRoomTest.java
@@ -1,8 +1,11 @@
 package com.thirdparty.ticketing.global.waitingsystem.memory.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.Assertions.within;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -214,6 +217,44 @@ class MemoryRunningRoomTest {
 
             // then
             assertThat(room.get(performanceId).get(email)).isEqualTo(waitingMember);
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 만료 시간 업데이트 시")
+    class UpdateRunningMemberExpiredTimeTest {
+
+        @Test
+        @DisplayName("사용자의 만료 시간을 5분으로 업데이트 한다.")
+        void updateRunningMemberExpiredTime() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            runningRoom.enter(performanceId, Set.of(new WaitingMember(email, performanceId)));
+
+            //when
+            runningRoom.updateRunningMemberExpiredTime(email, performanceId);
+
+            //then
+            WaitingMember waitingMember = room.get(performanceId).get(email);
+            assertThat(waitingMember.getEnteredAt()).isCloseTo(ZonedDateTime.now().plusMinutes(5),
+                    within(1, ChronoUnit.SECONDS));
+        }
+
+        @Test
+        @DisplayName("사용자가 작업 공간에 존재하지 않으면 무시한다.")
+        void ignore_notExistsMember() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            room.put(performanceId, new ConcurrentHashMap<>());
+
+            //when
+            Exception exception = catchException(
+                    () -> runningRoom.updateRunningMemberExpiredTime(email, performanceId));
+
+            //then
+            assertThat(exception).doesNotThrowAnyException();
         }
     }
 }

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -1,8 +1,15 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
+import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
+import com.thirdparty.ticketing.support.TestContainerStarter;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -14,13 +21,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
 import com.thirdparty.ticketing.support.BaseIntegrationTest;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 class RedisRunningRoomTest extends BaseIntegrationTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired private RedisRunningRoom runningRoom;
 
@@ -140,6 +151,26 @@ class RedisRunningRoomTest extends BaseIntegrationTest {
             List<Double> score = rawRunningRoom.score(getRunningRoomKey(performanceId), emails);
             assertThat(score).allSatisfy(value -> assertThat(value).isNotNull());
         }
+
+        @Test
+        @DisplayName("최초 입장 시 사용자의 작업 만료 시간은 30초이다.")
+        void test() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            Set<WaitingMember> waitingMembers = Set.of(
+                    new WaitingMember(email, performanceId, 1, ZonedDateTime.now()));
+
+            //when
+            runningRoom.enter(performanceId, waitingMembers);
+
+            //then
+            Double score = rawRunningRoom.score(getRunningRoomKey(performanceId), email);
+            ZonedDateTime zonedDateTime = ZonedDateTime.of(
+                    LocalDateTime.ofEpochSecond(score.longValue(), 0, ZoneOffset.of("+09:00")),
+                    ZoneId.of("Asia/Seoul"));
+            assertThat(zonedDateTime).isCloseTo(ZonedDateTime.now().plusSeconds(30), within(1, ChronoUnit.SECONDS));
+        }
     }
 
     @Nested
@@ -202,12 +233,12 @@ class RedisRunningRoomTest extends BaseIntegrationTest {
     class RemoveExpiredMemberInfoTest {
 
         @Test
-        @DisplayName("입장한지 5분이 지난 사용자 정보를 제거한다.")
+        @DisplayName("만료 시간이 현재 이전인 경우 제거한다.")
         void removeExpiredMemberInfo() {
             // given
             long performanceId = 1;
             String email = "email@email.com";
-            long score = ZonedDateTime.now().minusMinutes(5).minusSeconds(1).toEpochSecond();
+            long score = ZonedDateTime.now().minusSeconds(1).toEpochSecond();
             rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
 
             // when
@@ -218,12 +249,12 @@ class RedisRunningRoomTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("입장한지 5분이 지나지 않은 사용자 정보는 제거하지 않는다.")
+        @DisplayName("만료 시간이 현재 시간 이후인 사용자 정보는 제거하지 않는다.")
         void notRemoveMemberInfo() {
             // given
             long performanceId = 1;
             String email = "email@email.com";
-            long score = ZonedDateTime.now().minusMinutes(5).plusSeconds(10).toEpochSecond();
+            long score = ZonedDateTime.now().plusSeconds(10).toEpochSecond();
             rawRunningRoom.add(getRunningRoomKey(performanceId), email, score);
 
             // when

--- a/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
+++ b/src/test/java/com/thirdparty/ticketing/global/waitingsystem/redis/running/RedisRunningRoomTest.java
@@ -1,10 +1,12 @@
 package com.thirdparty.ticketing.global.waitingsystem.redis.running;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 import static org.assertj.core.api.Assertions.within;
 
 import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.TestContainerStarter;
+import com.thirdparty.ticketing.support.BaseIntegrationTest;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -13,7 +15,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,21 +22,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
-
-import com.thirdparty.ticketing.domain.waitingsystem.waiting.WaitingMember;
-import com.thirdparty.ticketing.support.BaseIntegrationTest;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 class RedisRunningRoomTest extends BaseIntegrationTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Autowired private RedisRunningRoom runningRoom;
+    @Autowired
+    private RedisRunningRoom runningRoom;
 
-    @Autowired private StringRedisTemplate redisTemplate;
+    @Autowired
+    private StringRedisTemplate redisTemplate;
 
     private ZSetOperations<String, String> rawRunningRoom;
 
@@ -265,6 +264,52 @@ class RedisRunningRoomTest extends BaseIntegrationTest {
                     .hasSize(1)
                     .first()
                     .isEqualTo(email);
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 만료 시간 업데이트 시")
+    class UpdateRunningMemberExpiredTimeTest {
+
+        @Test
+        @DisplayName("사용자의 만료 시간을 5분으로 업데이트 한다.")
+        void updateRunningMemberExpiredTime() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+            runningRoom.enter(performanceId, Set.of(new WaitingMember(email, performanceId)));
+
+            //when
+            runningRoom.updateRunningMemberExpiredTime(email, performanceId);
+
+            //then
+            assertThat(rawRunningRoom.rangeByScoreWithScores(getRunningRoomKey(performanceId), 0, Double.MAX_VALUE))
+                    .hasSize(1)
+                    .first()
+                    .satisfies(tuple -> {
+                        ZonedDateTime memberExpiredAt = ZonedDateTime.ofInstant(
+                                Instant.ofEpochSecond(tuple.getScore().longValue()),
+                                ZoneId.of("Asia/Seoul"));
+                        assertThat(memberExpiredAt).isCloseTo(
+                                ZonedDateTime.now().plusMinutes(5),
+                                within(1, ChronoUnit.MINUTES));
+                    });
+        }
+
+        @Test
+        @DisplayName("사용자가 작업 공간에 존재하지 않으면 무시한다.")
+        void ignore_notExistsMember() {
+            //given
+            long performanceId = 1;
+            String email = "email@email.com";
+
+            //when
+            Exception exception = catchException(
+                    () -> runningRoom.updateRunningMemberExpiredTime(email, performanceId));
+
+            //then
+            assertThat(exception).doesNotThrowAnyException();
+            assertThat(rawRunningRoom.zCard(getRunningRoomKey(performanceId))).isZero();
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 대기열 페이지에서 빠져나간 사용자를 구분하기 위한 로직을 추가했습니다.
- 작업 공간으로 최초 이동 시 사용자의 작업 공간 만료 시간을 30초로 설정하도록 변경했습니다.
- 사용자가 남은 순번 API 조회 시 남은 순번이 0이하인 경우 LastPolling 이벤트를 발행합니다.
- LastPolling 이벤트를 소비하는 이벤트 리스너가 사용자의 작업 공간 만료 시간을 5분으로 변경합니다.

### 📝 작업 요약
- 대기열 페이지에서 빠져나간 사용자의 만료 시간과 머무른 사용자의 만료 시간을 구분

### 💡 관련 이슈
- close #149 
